### PR TITLE
New rustup_toolchain type/provider

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -493,9 +493,10 @@ Use the [`rustup`](#rustup) defined type instead of this.
 
 The name should be the username.
 
-**Autorequires:** If Puppet is managing the `user` or the directories or
-their parents specified as `cargo_home` and `rustup_home`, then those
-resources will be autorequired.
+**Autorequires:**
+  * The `user`.
+  * The directory specified by `cargo_home` and its parent.
+  * The directory specified by `rustup_home` and its parent.
 
 #### Properties
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -19,6 +19,7 @@
 ### Resource types
 
 * [`rustup_internal`](#rustup_internal): Manage a user’s Rust installation with `rustup`
+* [`rustup_toolchain`](#rustup_toolchain): Manage a toolchain
 
 ### Functions
 
@@ -438,10 +439,6 @@ the toolchain. For example:
 rustup::toolchain { 'daniel: stable': }
 ```
 
-This cannot reliably check for the presence of a toolchain. It will not
-install the toolchain if another toolchain that matches `$egrep` is already
-installed.
-
 #### Parameters
 
 The following parameters are available in the `rustup::toolchain` defined type:
@@ -449,13 +446,17 @@ The following parameters are available in the `rustup::toolchain` defined type:
 * [`ensure`](#ensure)
 * [`user`](#user)
 * [`toolchain`](#toolchain)
-* [`egrep`](#egrep)
+* [`home`](#home)
+* [`rustup_home`](#rustup_home)
+* [`cargo_home`](#cargo_home)
 
 ##### <a name="ensure"></a>`ensure`
 
-Data type: `Enum[present, absent]`
+Data type: `Enum[present, latest, absent]`
 
-Whether the toolchain should be present or absent.
+* `present` - install toolchain if it doesn’t exist, but don’t update it.
+* `latest` - install toolchain and update it on every puppet run.
+* `absent` - uninstall toolchain.
 
 Default value: `present`
 
@@ -477,13 +478,30 @@ the `$name` of the resource follows the rules above.
 
 Default value: `(': ')[1]`
 
-##### <a name="egrep"></a>`egrep`
+##### <a name="home"></a>`home`
 
-Data type: `String[1]`
+Data type: `Stdlib::Absolutepath`
 
-`egrep` compatible regular expression to match the toolchain in the list.
+The user’s home directory. This defaults to `/home/$user` on Linux and
+`/Users/$user` on macOS.
 
-Default value: `"^${toolchain.regsubst('-', '-(.+-)?', 'G')}"`
+Default value: `rustup::home($user)`
+
+##### <a name="rustup_home"></a>`rustup_home`
+
+Data type: `Stdlib::Absolutepath`
+
+Where toolchains are installed. Generally you shouldn’t change this.
+
+Default value: `"${home}/.rustup"`
+
+##### <a name="cargo_home"></a>`cargo_home`
+
+Data type: `Stdlib::Absolutepath`
+
+Where `cargo` installs executables. Generally you shouldn’t change this.
+
+Default value: `"${home}/.cargo"`
 
 ## Resource types
 
@@ -564,6 +582,72 @@ Default value: `.rustup` in `user`’s home directory.
 namevar
 
 The user that owns this instance of `rustup` (autorequired).
+
+### <a name="rustup_toolchain"></a>`rustup_toolchain`
+
+The name should start with the username followed by a colon and a space,
+then the toolchain. For example:
+
+```puppet
+rustup::toolchain { 'daniel: stable': }
+```
+
+**Autorequires:**
+  * The `user`.
+  * The `rustup` resource with a name matching `user`.
+
+#### Properties
+
+The following properties are available in the `rustup_toolchain` type.
+
+##### `ensure`
+
+Valid values: `present`, `latest`, `absent`
+
+* `present` - install toolchain, but don’t update it.
+* `latest` - install toolchain and update it on every puppet run.
+* `absent` - uninstall toolchain.
+
+Default value: `present`
+
+#### Parameters
+
+The following parameters are available in the `rustup_toolchain` type.
+
+* [`cargo_home`](#cargo_home)
+* [`provider`](#provider)
+* [`rustup_home`](#rustup_home)
+* [`toolchain`](#toolchain)
+* [`user`](#user)
+
+##### <a name="cargo_home"></a>`cargo_home`
+
+Where `cargo` installs executables. Generally you shouldn’t change this.
+
+Default value: `.cargo` in `user`’s home directory.
+
+##### <a name="provider"></a>`provider`
+
+The specific backend to use for this `rustup_toolchain` resource. You will seldom need to specify this --- Puppet will
+usually discover the appropriate provider for your platform.
+
+##### <a name="rustup_home"></a>`rustup_home`
+
+Where toolchains are installed. Generally you shouldn’t change this.
+
+Default value: `.rustup` in `user`’s home directory.
+
+##### <a name="toolchain"></a>`toolchain`
+
+namevar
+
+The toolchain
+
+##### <a name="user"></a>`user`
+
+namevar
+
+The user that owns this toolchain (autorequired).
 
 ## Functions
 

--- a/lib/puppet/provider/rustup_exec.rb
+++ b/lib/puppet/provider/rustup_exec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+# Base class for rustup providers
+class Puppet::Provider::RustupExec < Puppet::Provider
+  # It’s not really reliable to query rustup installations by user, since they
+  # could be installed with CARGO_HOME anywhere.
+  def self.instances
+    fail "Cannot query rustup installations."
+  end
+
+  # For whatever reason, the resource expected this. An alternate solution is to
+  # call mk_resource_methods in child classes, but that adds a bunch more
+  # unnecessary methods that modify @property_hash. We don’t use @property_hash
+  # at all, since we can just access the resource itself.
+  def ensure=(value)
+  end
+
+  # Get the cargo home set on the resource, or figure out what it should be
+  def cargo_home
+    resource[:cargo_home] || File.join(home_path(), ".cargo")
+  end
+
+  # Get the rustup home set on the resource, or figure out what it should be
+  def rustup_home
+    resource[:rustup_home] || File.join(home_path(), ".rustup")
+  end
+
+  # Determine if the resource exists on the system
+  def exists?
+    fail "Unimplemented."
+  end
+
+  # Changes have been made to the resource; apply them.
+  def flush
+    if exists?
+      if resource[:ensure] == :absent
+        uninstall
+      elsif resource[:ensure] == :latest
+        update
+      end
+    elsif resource[:ensure] != :absent
+      # Does not exist, but should.
+      install
+    end
+  end
+
+protected
+
+  # Install resource for the first time.
+  #
+  # Will only be called if both:
+  #   * exists? == false
+  #   * ensure != :absent
+  def install
+    fail "Unimplemented."
+  end
+
+  # Update a previously installed resource.
+  #
+  # Will only be called if both:
+  #   * exists? == true
+  #   * ensure == :latest
+  def update
+    fail "Unimplemented."
+  end
+
+  # Uninstall a previously installed resource.
+  #
+  # Will only be called if both:
+  #   * exists? == true
+  #   * ensure == :absent
+  def uninstall
+    fail "Unimplemented."
+  end
+
+  # Run a command as the user
+  def execute(command, stdin_file: nil, raise_on_failure: true)
+    environment = {
+      "PATH" => path_env(),
+      "RUSTUP_HOME" => rustup_home(),
+      "CARGO_HOME" => cargo_home(),
+    }
+
+    stdin_message = stdin_file ? " and stdin_file #{stdin_file}" : ""
+    debug("Running #{command} for user #{resource[:user]} with environment" +
+      " #{environment}#{stdin_message}")
+
+    # FIXME timeout?
+    Puppet::Util::Execution.execute(
+      command,
+      :failonfail => raise_on_failure,
+      :uid => resource[:user],
+      :combine => true,
+      :stdinfile => stdin_file,
+      :override_locale => false,
+      :custom_environment => environment,
+    )
+  end
+
+  # Run rustup as the user
+  def rustup(*args)
+    execute([rustup_path()] + args)
+  end
+
+  # Get path to rustup binary
+  def rustup_path
+    File.join(bin_path(), "rustup")
+  end
+
+  # Get PATH, including cargo_home/bin
+  def path_env
+    "#{bin_path()}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  end
+
+  # Get path to directory where cargo installs binaries
+  def bin_path
+    File.join(cargo_home(), "bin")
+  end
+
+  # Get user’s HOME path from the user database
+  def home_path
+    Etc.getpwnam(resource[:user]).dir
+  end
+
+  # Output a debugging message
+  def debug(message)
+    Puppet.debug("#{self.class.resource_type.name}: #{message}")
+  end
+end

--- a/lib/puppet/provider/rustup_internal/shell.rb
+++ b/lib/puppet/provider/rustup_internal/shell.rb
@@ -1,51 +1,26 @@
 # frozen_string_literal: true
 
-Puppet::Type.type(:rustup_internal).provide(:shell) do
+require_relative "../rustup_exec"
+
+Puppet::Type.type(:rustup_internal).provide(
+  :shell, :parent => Puppet::Provider::RustupExec
+) do
   desc "Run shell-based `rustup` installer on UNIX-like platforms."
 
-  # It’s not really reliable to query rustup installations by user, since they
-  # could be installed with CARGO_HOME anywhere.
-  def self.instances
-    fail "Cannot query rustup installations."
-  end
-
-  # For whatever reason, the resource expected this. An alternate solution is
-  # to call mk_resource_methods, but that adds a bunch more unnecessary methods
-  # that modify @property_hash. We don’t use @property_hash at all, since we
-  # can just access the resource itself.
-  def ensure=(value)
-  end
-
-  def cargo_home
-    resource[:cargo_home] || File.join(home_path(), ".cargo")
-  end
-
-  def rustup_home
-    resource[:rustup_home] || File.join(home_path(), ".rustup")
-  end
-
+  # Determine if `rustup` has been installed on the system for this user
   def exists?
     # FIXME? this actually checks that root can execute the file. Also, it
     # doesn’t check that it’s not a directory.
     File.executable?(rustup_path())
   end
 
-  # Changes have been made to the resource; apply them.
-  def flush
-    if exists?
-      if resource[:ensure] == :absent
-        uninstall
-      elsif resource[:ensure] == :latest
-        update
-      end
-    elsif resource[:ensure] != :absent
-      # Does not exist, but should.
-      install
-    end
-  end
+protected
 
-private
-
+  # Install `rustup` for the first time.
+  #
+  # Will only be called if both:
+  #   * exists? == false
+  #   * ensure != :absent
   def install
     # Puppet::Util::Execution.execute can’t accept an IO stream or a string as
     # stdin, so we save the script as a file and pipe it into stdin. (We don’t
@@ -75,36 +50,25 @@ private
     end
   end
 
+  # Update previously installed `rustup`.
+  #
+  # Will only be called if both:
+  #   * exists? == true
+  #   * ensure == :latest
   def update
     rustup "self", "update"
   end
 
+  # Uninstall previously installed `rustup`.
+  #
+  # Will only be called if both:
+  #   * exists? == true
+  #   * ensure == :absent
   def uninstall
     rustup "self", "uninstall", "-y"
   end
 
-  def execute(command, stdin_file: nil, raise_on_failure: true)
-    environment = {
-      "PATH" => path_env(),
-      "RUSTUP_HOME" => rustup_home(),
-      "CARGO_HOME" => cargo_home(),
-    }
-
-    stdin_message = stdin_file ? " and stdin_file #{stdin_file}" : ""
-    debug("Running #{command} for user #{resource[:user]} with environment #{environment}#{stdin_message}")
-
-    # FIXME timeout?
-    Puppet::Util::Execution.execute(
-      command,
-      :failonfail => raise_on_failure,
-      :uid => resource[:user],
-      :combine => true,
-      :stdinfile => stdin_file,
-      :override_locale => false,
-      :custom_environment => environment,
-    )
-  end
-
+  # Download a URL into a stream
   def download_into(url, output)
     client = Puppet.runtime[:http]
     client.get(url, options: {include_system_store: true}) do |response|
@@ -120,31 +84,4 @@ private
       end
     end
   end
-
-  # Convenience function to run rustup
-  def rustup(*args)
-    execute([rustup_path()] + args)
-  end
-
-  def rustup_path
-    File.join(bin_path(), "rustup")
-  end
-
-  def path_env
-    "#{bin_path()}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-  end
-
-  def bin_path
-    File.join(cargo_home(), "bin")
-  end
-
-  def home_path
-    Etc.getpwnam(resource[:user]).dir
-  end
-
-  def debug(message)
-    Puppet.debug("rustup_internal: #{message}")
-  end
 end
-
-

--- a/lib/puppet/provider/rustup_internal/shell.rb
+++ b/lib/puppet/provider/rustup_internal/shell.rb
@@ -17,17 +17,17 @@ Puppet::Type.type(:rustup_internal).provide(:shell) do
   end
 
   def cargo_home
-    resource[:cargo_home] || File.join(home(), ".cargo")
+    resource[:cargo_home] || File.join(home_path(), ".cargo")
   end
 
   def rustup_home
-    resource[:rustup_home] || File.join(home(), ".rustup")
+    resource[:rustup_home] || File.join(home_path(), ".rustup")
   end
 
   def exists?
     # FIXME? this actually checks that root can execute the file. Also, it
     # doesn’t check that it’s not a directory.
-    File.executable?(rustup())
+    File.executable?(rustup_path())
   end
 
   # Changes have been made to the resource; apply them.
@@ -76,11 +76,11 @@ private
   end
 
   def update
-    execute([rustup(), "self", "update"])
+    rustup "self", "update"
   end
 
   def uninstall
-    execute([rustup(), "self", "uninstall", "-y"])
+    rustup "self", "uninstall", "-y"
   end
 
   def execute(command, stdin_file: nil, raise_on_failure: true)
@@ -121,19 +121,24 @@ private
     end
   end
 
-  def rustup
-    File.join(bin(), "rustup")
+  # Convenience function to run rustup
+  def rustup(*args)
+    execute([rustup_path()] + args)
+  end
+
+  def rustup_path
+    File.join(bin_path(), "rustup")
   end
 
   def path_env
-    "#{bin()}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    "#{bin_path()}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
   end
 
-  def bin
+  def bin_path
     File.join(cargo_home(), "bin")
   end
 
-  def home
+  def home_path
     Etc.getpwnam(resource[:user]).dir
   end
 

--- a/lib/puppet/provider/rustup_toolchain/exec.rb
+++ b/lib/puppet/provider/rustup_toolchain/exec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require_relative "../rustup_exec"
+
+Puppet::Type.type(:rustup_toolchain).provide(
+  :exec, :parent => Puppet::Provider::RustupExec
+) do
+  desc "Use `rustup` to manage toolchains."
+
+  # Determine if this toolchain has been installed on the system for this user
+  def exists?
+    make_toolchain_matcher(resource[:toolchain]).match?(
+      rustup("toolchain", "list"))
+  end
+
+  # There are some flaws in this.
+  #
+  #   * If you have non-host toolchains (e.g. you run an ARM toolchain on x86_64
+  #     under emulation), this may incorrectly match one of them. For example,
+  #     if you have stable-aarch64-apple-ios installed on your x86_64 host, this
+  #     will match that even though it should not.
+  #
+  #   * It will break as soon as rust adds a new triple to run toolchains on.
+  def make_toolchain_matcher(partial)
+    # From https://github.com/rust-lang/rustup/blob/6bc5d2c340e1dd9880b68564a19f0dea384c849c/src/dist/triple.rs
+    archs = [
+      "i386",
+      "i586",
+      "i686",
+      "x86_64",
+      "arm",
+      "armv7",
+      "armv7s",
+      "aarch64",
+      "mips",
+      "mipsel",
+      "mips64",
+      "mips64el",
+      "powerpc",
+      "powerpc64",
+      "powerpc64le",
+      "riscv64gc",
+      "s390x",
+    ].join('|')
+    oses = [
+      "pc-windows",
+      "unknown-linux",
+      "apple-darwin",
+      "unknown-netbsd",
+      "apple-ios",
+      "linux",
+      "rumprun-netbsd",
+      "unknown-freebsd",
+      "unknown-illumos",
+    ].join('|')
+    envs = [
+      "gnu",
+      "gnux32",
+      "msvc",
+      "gnueabi",
+      "gnueabihf",
+      "gnuabi64",
+      "androideabi",
+      "android",
+      "musl",
+    ].join('|')
+    re = /\A(.+?)(?:-(#{archs}))?(?:-(#{oses}))?(?:-(#{envs}))?\Z/
+    parts = re.match(partial)[1,4].map do |part|
+      if part.nil?
+        ".+"
+      else
+        Regexp.escape(part)
+      end
+    end
+    /^#{parts.join('-')}(?: \(default\))?$/
+  end
+
+protected
+
+  # Install toolchain for the first time.
+  #
+  # Will only be called if both:
+  #   * exists? == false
+  #   * ensure != :absent
+  def install
+    rustup "toolchain", "install", "--no-self-update", resource[:toolchain]
+  end
+
+  # Update previously installed `rustup`.
+  #
+  # Will only be called if both:
+  #   * exists? == true
+  #   * ensure == :latest
+  def update
+    install
+  end
+
+  # Uninstall a previously installed toolchain.
+  #
+  # Will only be called if both:
+  #   * exists? == true
+  #   * ensure == :absent
+  def uninstall
+    rustup "toolchain", "uninstall", resource[:toolchain]
+  end
+end

--- a/lib/puppet/type/rustup_internal.rb
+++ b/lib/puppet/type/rustup_internal.rb
@@ -95,8 +95,8 @@ Puppet::Type.newtype(:rustup_internal) do
     defaultto 'https://sh.rustup.rs'
 
     validate do |value|
-      if value.empty?
-        fail 'Installer source must not be blank.'
+      if !value.is_a?(String) || value.empty?
+        fail 'Installer source must be a valid URL, not "%s".' % value
       end
       begin
         URI.parse(value)

--- a/lib/puppet/type/rustup_internal.rb
+++ b/lib/puppet/type/rustup_internal.rb
@@ -10,9 +10,10 @@ Puppet::Type.newtype(:rustup_internal) do
 
     The name should be the username.
 
-    **Autorequires:** If Puppet is managing the `user` or the directories or
-    their parents specified as `cargo_home` and `rustup_home`, then those
-    resources will be autorequired.
+    **Autorequires:**
+      * The `user`.
+      * The directory specified by `cargo_home` and its parent.
+      * The directory specified by `rustup_home` and its parent.
   END
 
   ensurable do

--- a/lib/puppet/type/rustup_toolchain.rb
+++ b/lib/puppet/type/rustup_toolchain.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+Puppet::Type.newtype(:rustup_toolchain) do
+  @doc = <<~'END'
+    @summary Manage a toolchain
+
+    The name should start with the username followed by a colon and a space,
+    then the toolchain. For example:
+
+    ```puppet
+    rustup::toolchain { 'daniel: stable': }
+    ```
+
+    **Autorequires:**
+      * The `user`.
+      * The `rustup` resource with a name matching `user`.
+  END
+
+  ensurable do
+    desc <<~'END'
+      * `present` - install toolchain, but don’t update it.
+      * `latest` - install toolchain and update it on every puppet run.
+      * `absent` - uninstall toolchain.
+    END
+
+    newvalues :present, :latest, :absent
+    defaultto :present
+  end
+
+  newparam(:user) do
+    isnamevar
+    desc 'The user that owns this toolchain (autorequired).'
+
+    validate do |value|
+      if !value.is_a?(String) || value.empty?
+        fail 'User is required to be a non-empty string.'
+      end
+    end
+  end
+
+  autorequire(:user) { [self[:user]] }
+  autorequire(:rustup) { [self[:user]] }
+
+  newparam(:toolchain) do
+    isnamevar
+    desc 'The toolchain'
+
+    validate do |value|
+      if !value.is_a?(String) || value.empty?
+        fail 'Toolchain is required to be a non-empty string.'
+      end
+    end
+  end
+
+  validate do
+    if !self[:user].is_a?(String) || self[:user].empty?
+      fail 'User is required to be a non-empty string.'
+    elsif !self[:toolchain].is_a?(String) || self[:toolchain].empty?
+      fail 'Toolchain is required to be a non-empty string.'
+    end
+  end
+
+  newparam(:cargo_home) do
+    desc <<~'END'
+      Where `cargo` installs executables. Generally you shouldn’t change this.
+
+      Default value: `.cargo` in `user`’s home directory.
+    END
+
+    validate do |value|
+      # need ! value.nil? && ?
+      if ! Puppet::Util.absolute_path?(value)
+        fail 'Cargo home must be an absolute path, not "%s"' % value
+      end
+    end
+  end
+
+  newparam(:rustup_home) do
+    desc <<~'END'
+      Where toolchains are installed. Generally you shouldn’t change this.
+
+      Default value: `.rustup` in `user`’s home directory.
+    END
+
+    validate do |value|
+      # need ! value.nil? && ?
+      if ! Puppet::Util.absolute_path?(value)
+        fail 'Rustup home must be an absolute path, not "%s"' % value
+      end
+    end
+  end
+
+  def self.title_patterns
+    [
+      [
+        /\A(.+?): (.+)\Z/,
+        [
+          [ :user ],
+          [ :toolchain ],
+        ]
+      ],
+      # Allow title to be non-structured as long as parameters are set. Accepts
+      # an empty string because the error for a missing toolchain is better than
+      # “No set of title patterns matched…”
+      [
+        /\A(.*?)\Z/,
+        [
+          [ :toolchain ],
+        ]
+      ]
+    ]
+  end
+end
+

--- a/spec/unit/puppet/provider/rustup_toolchain/exec_spec.rb
+++ b/spec/unit/puppet/provider/rustup_toolchain/exec_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Puppet::Type.type(:rustup_toolchain).provider(:exec) do
+  it "should refuse to load instances" do
+    expect { described_class.instances }
+      .to raise_error(RuntimeError, /Cannot query rustup installations/)
+  end
+
+  let :resource do
+    Puppet::Type.type(:rustup_toolchain).new(
+      :title => "root: toolchain",
+      :provider => :exec,
+    )
+  end
+
+  let :provider do
+    described_class.new(resource)
+  end
+
+  it "has correct rustup_home" do
+    expect(provider.rustup_home).to eq(File.expand_path("~root/.rustup"))
+  end
+
+  context "produces good toolchain matchers" do
+    it 'for "stable"' do
+      expect(provider.make_toolchain_matcher("stable"))
+        .to eq(/^stable-.+-.+-.+(?: \(default\))?$/)
+    end
+
+    it 'for "custom-toolchain"' do
+      expect(provider.make_toolchain_matcher("custom-toolchain"))
+        .to eq(/^custom\-toolchain-.+-.+-.+(?: \(default\))?$/)
+    end
+
+    it 'for "custom-toolchain-mscv"' do
+      expect(provider.make_toolchain_matcher("custom-toolchain-msvc"))
+        .to eq(/^custom\-toolchain-.+-.+-msvc(?: \(default\))?$/)
+    end
+
+    it 'for "custom-toolchain-pc-windows"' do
+      expect(provider.make_toolchain_matcher("custom-toolchain-pc-windows"))
+        .to eq(/^custom\-toolchain-.+-pc\-windows-.+(?: \(default\))?$/)
+    end
+  end
+end

--- a/spec/unit/puppet/provider/rustup_toolchain/exec_spec.rb
+++ b/spec/unit/puppet/provider/rustup_toolchain/exec_spec.rb
@@ -16,32 +16,40 @@ RSpec.describe Puppet::Type.type(:rustup_toolchain).provider(:exec) do
   end
 
   let :provider do
-    described_class.new(resource)
+    provider = described_class.new(resource)
+    allow(provider).to receive(:load_default_triple) \
+      .and_return("x86_64-apple-darwin")
+    provider
   end
 
   it "has correct rustup_home" do
     expect(provider.rustup_home).to eq(File.expand_path("~root/.rustup"))
   end
 
+  it "parses default toolchain correctly" do
+    expect(provider.parse_default_triple)
+      .to eq(["", "x86_64", "apple-darwin", nil])
+  end
+
   context "produces good toolchain matchers" do
     it 'for "stable"' do
       expect(provider.make_toolchain_matcher("stable"))
-        .to eq(/^stable-.+-.+-.+(?: \(default\))?$/)
+        .to eq(/^stable-x86_64-apple-darwin(?: \(default\))?$/)
     end
 
     it 'for "custom-toolchain"' do
       expect(provider.make_toolchain_matcher("custom-toolchain"))
-        .to eq(/^custom\-toolchain-.+-.+-.+(?: \(default\))?$/)
+        .to eq(/^custom\-toolchain-x86_64-apple-darwin(?: \(default\))?$/)
     end
 
     it 'for "custom-toolchain-mscv"' do
       expect(provider.make_toolchain_matcher("custom-toolchain-msvc"))
-        .to eq(/^custom\-toolchain-.+-.+-msvc(?: \(default\))?$/)
+        .to eq(/^custom\-toolchain-x86_64-apple-darwin-msvc(?: \(default\))?$/)
     end
 
     it 'for "custom-toolchain-pc-windows"' do
       expect(provider.make_toolchain_matcher("custom-toolchain-pc-windows"))
-        .to eq(/^custom\-toolchain-.+-pc\-windows-.+(?: \(default\))?$/)
+        .to eq(/^custom\-toolchain-x86_64-pc\-windows(?: \(default\))?$/)
     end
   end
 end

--- a/spec/unit/puppet/type/rustup_internal_spec.rb
+++ b/spec/unit/puppet/type/rustup_internal_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe Puppet::Type.type(:rustup_internal) do
       .to raise_error(Puppet::Error, /Title or name must be provided/)
   end
 
+  it "fails with a blank name" do
+    expect { described_class.new(:name => "") }
+      .to raise_error(Puppet::Error, /User is required to be a non-empty string/)
+  end
+
   it "fails with a bad ensure" do
     expect { described_class.new(:name => "user", :ensure => "dfasdf") }
       .to raise_error(Puppet::Error, /Valid values are present, latest, absent/)
@@ -31,17 +36,42 @@ RSpec.describe Puppet::Type.type(:rustup_internal) do
       .to eq(false)
   end
 
-  it "fails with a blank installer_source" do
-    expect { described_class.new(:name => "user", :installer_source => "") }
-      .to raise_error(Puppet::Error, /Installer source must not be blank/)
+  it "fails with a relative rustup_home" do
+    expect { described_class.new(:name => "user", :rustup_home => "dfasdf") }
+      .to raise_error(Puppet::Error, /Rustup home must be an absolute path/)
   end
 
-  it "fails with a bad installer_source" do
+  it "fails with a nil rustup_home" do
+    expect { described_class.new(:name => "user", :rustup_home => nil) }
+      .to raise_error(Puppet::Error, /Got nil value for rustup_home/)
+  end
+
+  it "works with an absolute rustup_home" do
+    expect(described_class.new(:name => "user", :rustup_home => "/opt/rustup"))
+      .not_to be_nil
+  end
+
+  it "fails with a number installer_source" do
+    expect { described_class.new(:name => "user", :installer_source => 3) }
+      .to raise_error(Puppet::Error, /Installer source must be a valid URL/)
+  end
+
+  it "fails with a nil installer_source" do
+    expect { described_class.new(:name => "user", :installer_source => nil) }
+      .to raise_error(Puppet::Error, /Got nil value for installer_source/)
+  end
+
+  it "fails with a blank installer_source" do
+    expect { described_class.new(:name => "user", :installer_source => "") }
+      .to raise_error(Puppet::Error, /Installer source must be a valid URL/)
+  end
+
+  it "fails with a non-URL installer_source" do
     expect { described_class.new(:name => "user", :installer_source => "s a as") }
       .to raise_error(Puppet::Error, /Installer source must be a valid URL/)
   end
 
-  it "works with a good installer_source" do
+  it "works with a URL installer_source" do
     expect(described_class.new(:name => "user", :installer_source => "http://localhost/foo"))
       .to_not be_nil
   end

--- a/spec/unit/puppet/type/rustup_toolchain_spec.rb
+++ b/spec/unit/puppet/type/rustup_toolchain_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Puppet::Type.type(:rustup_toolchain) do
+  it "loads" do
+    expect(described_class).not_to be_nil
+  end
+
+  it "creates a trivial instance" do
+    instance = described_class.new(:title => "u: t")
+    expect(instance).to_not be_nil
+    expect(instance[:user]).to eq("u")
+    expect(instance[:toolchain]).to eq("t")
+  end
+
+  it "fails with a nil title" do
+    expect { described_class.new(:title => nil) }
+      .to raise_error(Puppet::Error, /Title or name must be provided/)
+  end
+
+  it "fails with an empty title" do
+    expect { described_class.new(:title => "") }
+      .to raise_error(Puppet::Error, /Toolchain is required/)
+  end
+
+  it "fails with an non-structured title" do
+    expect { described_class.new(:title => "a") }
+      .to raise_error(Puppet::Error, /User is required/)
+  end
+
+  it "works with an non-structured title and parameters" do
+    instance = described_class.new(
+      :title => "a",
+      :user => "u",
+      :toolchain => "t")
+    expect(instance).to_not be_nil
+    expect(instance[:user]).to eq("u")
+    expect(instance[:toolchain]).to eq("t")
+  end
+
+  it "fails with a bad ensure" do
+    expect { described_class.new(:title => "u: t", :ensure => "dfasdf") }
+      .to raise_error(Puppet::Error, /Valid values are present, latest, absent/)
+  end
+
+  it "fails with a relative rustup_home" do
+    expect { described_class.new(:title => "u: t", :rustup_home => ".") }
+      .to raise_error(Puppet::Error, /Rustup home must be an absolute path/)
+  end
+
+  it "works with an absolute rustup_home" do
+    expect(described_class.new(:title => "u: t", :rustup_home => "/opt/rustup"))
+      .not_to be_nil
+  end
+end


### PR DESCRIPTION
  * Add `ensure => latest` support.
  * Autorequires the `rustup` resource.
  * Better matching for installed toolchains.
  * Refactor provider code into common base class.