### PR TITLE
Ensure changes to shell init scripts are removed

### DIFF
--- a/lib/puppet/type/rustup_internal.rb
+++ b/lib/puppet/type/rustup_internal.rb
@@ -44,8 +44,7 @@ Puppet::Type.newtype(:rustup_internal) do
   newparam(:modify_path, boolean: true, parent: Puppet::Parameter::Boolean) do
     desc <<~'END'
       Whether or not to let `rustup` modify the user’s `PATH` in their shell
-      init scripts. Changing this will have no effect after the initial
-      installation.
+      init scripts. This only affects the initial installation and removal.
     END
 
     defaultto true

--- a/lib/puppet_x/rustup/util.rb
+++ b/lib/puppet_x/rustup/util.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Guard clauses are sometimes ambigious, and often harder to read.
+# rubocop:disable Style/GuardClause
+
+require 'puppet_x'
+
+# Support module for rustup
+module PuppetX::Rustup
+  # Utility functions for rustup
+  module Util
+    # Remove a line from a file.
+    #
+    # This does the removal in place to avoid problems with symlinks, hard
+    # links, and preserving metadata (like modes and ACLs). This means the
+    # removal is not atomic.
+    #
+    # This only writes to the file if changes are made.
+    #
+    # line_to_remove is a string that matches the line to remove, not including
+    # newlines.
+    def self.remove_file_line(path, line_to_remove)
+      matcher = Regexp.escape(line_to_remove)
+      contents = IO.read(path)
+      if contents.gsub!(%r{^#{matcher}(\n|\r\n|\r|\Z)}, '')
+        # Substitutions were made
+        IO.write(path, contents)
+      end
+    end
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@
 #   Where `cargo` installs executables. Generally you shouldn’t change this.
 # @param modify_path
 #   Whether or not to let `rustup` modify the user’s `PATH` in their shell init
-#   scripts. Changing this will have no effect after the initial installation.
+#   scripts. This only affects the initial installation and removal.
 # @param installer_source
 #   URL of the rustup installation script. Changing this will have no effect
 #   after the initial installation.
@@ -43,27 +43,5 @@ define rustup (
     cargo_home       => $cargo_home,
     modify_path      => $modify_path,
     installer_source => $installer_source,
-  }
-
-  if $ensure == absent {
-    file { [$rustup_home, $cargo_home]:
-      ensure  => absent,
-      force   => true,
-      require => Rustup_internal[$name],
-    }
-
-    # FIXME it would be nice to be able to enforce this, but we can’t guarantee
-    # these files exist. Plus, CentOS uses .bash_profile.
-    # if $modify_path {
-    #   [".bashrc", ".profile"].each |$file| {
-    #     $path = "${home}/${file}"
-    #     file_line { "${path} -. \"\$HOME/.cargo/env\"":
-    #       ensure            => absent,
-    #       path              => $path,
-    #       match             => '^[.] "\$HOME/\.cargo/env"$',
-    #       match_for_absence => true,
-    #     }
-    #   }
-    # }
   }
 }

--- a/spec/unit/puppet_x/rustup/util_spec.rb
+++ b/spec/unit/puppet_x/rustup/util_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../../lib/puppet_x/rustup/util.rb'
+
+RSpec.describe PuppetX::Rustup::Util do
+  context 'remove_file_line' do
+    # Run all tests in a temporary directory
+    around(:each) do |example|
+      Dir.mktmpdir(example.description.gsub(%r{[^a-z0-9_.-]+}i, '_')) do |path|
+        Dir.chdir(path) do
+          example.run
+        end
+      end
+    end
+
+    it 'does not change a file without the line' do
+      IO.write('input.txt', "line 1\nline 2\n")
+      old_inode = File.stat('input.txt').ino
+      described_class.remove_file_line('input.txt', 'REMOVE')
+      expect(File.stat('input.txt').ino).to eq old_inode
+      expect(Dir.children('.')).to eq ['input.txt']
+    end
+
+    it 'removes a line from a file in place' do
+      IO.write('input.txt', "line 1\nREMOVE\nline 3")
+      old_inode = File.stat('input.txt').ino
+      described_class.remove_file_line('input.txt', 'REMOVE')
+      expect(File.stat('input.txt').ino).to eq old_inode
+      expect(IO.read('input.txt')).to eq "line 1\nline 3"
+      expect(Dir.children('.')).to eq ['input.txt']
+    end
+
+    it 'preserves permissions when changing file' do
+      IO.write('input.txt', "line 1\nREMOVE\nline 3")
+      File.chmod(0o651, 'input.txt')
+      old_mode = '%o' % File.stat('input.txt').mode
+      described_class.remove_file_line('input.txt', 'REMOVE')
+      expect('%o' % File.stat('input.txt').mode).to eq old_mode
+      expect(IO.read('input.txt')).to eq "line 1\nline 3"
+      expect(Dir.children('.')).to eq ['input.txt']
+    end
+
+    it 'removes all lines from a file' do
+      IO.write('input.txt', "REMOVE\nREMOVE\nREMOVE")
+      described_class.remove_file_line('input.txt', 'REMOVE')
+      expect(IO.read('input.txt')).to eq ''
+      expect(Dir.children('.')).to eq ['input.txt']
+    end
+
+    it 'removes multiple lines from a file' do
+      IO.write('input.txt', "line 1\nREMOVE\nline 3\nREMOVE")
+      described_class.remove_file_line('input.txt', 'REMOVE')
+      expect(IO.read('input.txt')).to eq "line 1\nline 3\n"
+      expect(Dir.children('.')).to eq ['input.txt']
+    end
+
+    it 'does not remove similar lines from a file' do
+      IO.write('input.txt', "line 1\nREMOVE \nline 3\nREMOVE")
+      described_class.remove_file_line('input.txt', 'REMOVE')
+      expect(IO.read('input.txt')).to eq "line 1\nREMOVE \nline 3\n"
+      expect(Dir.children('.')).to eq ['input.txt']
+    end
+
+    it 'does not treat line to remove as a regular expression' do
+      IO.write('input.txt', "line 1\nREMO.E\nline 3\nREMOVE")
+      described_class.remove_file_line('input.txt', 'REMO.E')
+      expect(IO.read('input.txt')).to eq "line 1\nline 3\nREMOVE"
+      expect(Dir.children('.')).to eq ['input.txt']
+    end
+
+    it 'handles mixed newlines' do
+      IO.write('input.txt', "line 1\r\nREMOVE\rline 3\nREMOVE\r\n\rline 4")
+      described_class.remove_file_line('input.txt', 'REMOVE')
+      expect(IO.read('input.txt')).to eq "line 1\r\nline 3\n\rline 4"
+      expect(Dir.children('.')).to eq ['input.txt']
+    end
+  end
+end


### PR DESCRIPTION
If the user is removed before `rustup { 'user': ensure => absent }` runs, then it will not be able to run the uninstaller. This manually removes the `. "$HOME/.cargo/env"` line from RC scripts.