### PR TITLE
Switch to prefered method to call Puppet.debug

### DIFF
--- a/lib/puppet/provider/rustup_exec.rb
+++ b/lib/puppet/provider/rustup_exec.rb
@@ -79,9 +79,11 @@ class Puppet::Provider::RustupExec < Puppet::Provider
       'CARGO_HOME' => resource[:cargo_home],
     }
 
-    stdin_message = stdin_file ? " and stdin_file #{stdin_file}" : ''
-    debug("Running #{command} for user #{resource[:user]} with environment" \
-      " #{environment}#{stdin_message}")
+    debug do
+      stdin_message = stdin_file ? " and stdin_file #{stdin_file.inspect}" : ''
+      "Running #{command.inspect} for user #{resource[:user].inspect} with " \
+      "environment #{environment.inspect}#{stdin_message}"
+    end
 
     # FIXME: timeout?
     Puppet::Util::Execution.execute(
@@ -123,7 +125,14 @@ class Puppet::Provider::RustupExec < Puppet::Provider
   end
 
   # Output a debugging message
-  def debug(message)
-    Puppet.debug("#{self.class.resource_type.name}: #{message}")
+  def debug(*args)
+    Puppet.debug do
+      message = if block_given?
+                  yield(*args)
+                else
+                  args.join(' ')
+                end
+      "#{self.class.resource_type.name}: #{message}"
+    end
   end
 end

--- a/lib/puppet/provider/rustup_internal/shell.rb
+++ b/lib/puppet/provider/rustup_internal/shell.rb
@@ -28,7 +28,9 @@ Puppet::Type.type(:rustup_internal).provide(
     script = Tempfile.new(['puppet-rustup-init', '.sh'])
     begin
       url = URI.parse(resource[:installer_source])
-      debug("Starting download from #{url} into #{script.path}")
+      debug do
+        "Starting download from #{url.inspect} into #{script.path.inspect}"
+      end
       download_into(url, script)
       script.flush
 
@@ -43,7 +45,7 @@ Puppet::Type.type(:rustup_internal).provide(
         raise Puppet::ExecutionFailure, "Installing rustup failed: #{output}"
       end
     ensure
-      debug("Deleting #{script.path}")
+      debug { "Deleting #{script.path.inspect}" }
       script.close
       script.unlink
     end

--- a/lib/puppet/provider/rustup_toolchain/exec.rb
+++ b/lib/puppet/provider/rustup_toolchain/exec.rb
@@ -121,7 +121,7 @@ Puppet::Type.type(:rustup_toolchain).provide(
   def load_default_triple
     rustup('show').split(%r{[\r\n]+}).each do |line|
       if line =~ %r{^Default host:\s+(\S+)$}i
-        debug("Got default host (triple): #{Regexp.last_match(1)}")
+        debug { "Got default host (triple): #{Regexp.last_match(1).inspect}" }
         return Regexp.last_match(1)
       end
     end


### PR DESCRIPTION
I’m sure the performance difference is trivial, especially considering how I use it.