### PR TITLE
Support non-host toolchains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## main branch
+
+### Bug fixes
+
+* Now supports installing non-host toolchains for use with emulators. For
+  example, it is now possible to install the `x86_64-pc-windows-gnu` toolchain
+  on a Linux host without warnings.
+
+
 ## Release 0.1.0
 
-**Features**
+### Features
 
 * Install [Rust][] via [rustup][].
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ rustup::global::target { 'x86_64-unknown-linux-musl nightly': }
 
   * This does not allow management of components.
   * This does not allow management of profiles.
-  * This will not be able to install non-host toolchains in the future.
   * This does not support Windows.
 
 ## Reference

--- a/lib/puppet/provider/rustup_internal/default.rb
+++ b/lib/puppet/provider/rustup_internal/default.rb
@@ -435,7 +435,8 @@ Puppet::Type.type(:rustup_internal).provide(
 
   # Install or update a toolchain
   def toolchain_install(toolchain)
-    rustup 'toolchain', 'install', '--no-self-update', toolchain
+    rustup 'toolchain', 'install', '--no-self-update', '--force-non-host', \
+      toolchain
   end
 
   # Uninstall a toolchain

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -164,6 +164,28 @@ describe 'Per-user rustup management' do
     end
   end
 
+  context 'supports installing non-host toolchain' do
+    target = 'x86_64-pc-windows-gnu'
+    toolchain = "stable-#{target}"
+
+    it do
+      # Note that the quotes here are within the END block.
+      idempotent_apply(<<~END)
+        rustup { 'vagrant': }
+        rustup::toolchain { 'vagrant: #{toolchain}': }
+      END
+    end
+
+    command = "rustup target list --toolchain #{toolchain}"
+    describe command_as_vagrant(command) do
+      its(:stdout) do
+        is_expected.to match(%r{^#{target} \(installed\)$})
+      end
+      its(:stderr) { is_expected.to eq '' }
+      its(:exit_status) { is_expected.to eq 0 }
+    end
+  end
+
   context 'supports multi-resource uninstall for a real user' do
     it do
       idempotent_apply(<<~'END')


### PR DESCRIPTION
Now supports installing non-host toolchains for use with emulators. For example, it is now possible to install the `x86_64-pc-windows-gnu` toolchain on a Linux host without warnings.