### PR TITLE
Add profile parameter for toolchains

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ rustup::global::target { 'x86_64-unknown-linux-musl nightly': }
 ## Limitations
 
   * This does not allow management of components.
-  * This does not allow management of profiles.
   * This does not support Windows.
 
 ## Reference

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -28,6 +28,7 @@
 ### Data types
 
 * [`Rustup::OptionalStringOrArray`](#rustupoptionalstringorarray): Convenience type to make params easier to read
+* [`Rustup::Profile`](#rustupprofile): Profile for toolchain installation
 
 ## Classes
 
@@ -469,6 +470,7 @@ The following parameters are available in the `rustup::global::toolchain` define
 
 * [`ensure`](#ensure)
 * [`toolchain`](#toolchain)
+* [`profile`](#profile)
 
 ##### <a name="ensure"></a>`ensure`
 
@@ -487,6 +489,18 @@ Data type: `String[1]`
 The name of the toolchain to install, e.g. "stable".
 
 Default value: `$name`
+
+##### <a name="profile"></a>`profile`
+
+Data type: `Rustup::Profile`
+
+Profile to use for installation. This determines which components will be
+installed initially.
+
+Changing this for an existing installation will not have an effect even if
+it causes an update, i.e. when `ensure => latest` is set.
+
+Default value: `'default'`
 
 ### <a name="rustuptarget"></a>`rustup::target`
 
@@ -564,6 +578,7 @@ The following parameters are available in the `rustup::toolchain` defined type:
 * [`ensure`](#ensure)
 * [`rustup`](#rustup)
 * [`toolchain`](#toolchain)
+* [`profile`](#profile)
 
 ##### <a name="ensure"></a>`ensure`
 
@@ -592,6 +607,18 @@ The name of the toolchain to install, e.g. "stable". Automatically set if
 the `$name` of the resource follows the rules above.
 
 Default value: `(': ')[1]`
+
+##### <a name="profile"></a>`profile`
+
+Data type: `Rustup::Profile`
+
+Profile to use for installation. This determines which components will be
+installed initially.
+
+Changing this for an existing installation will not have an effect even if
+it causes an update, i.e. when `ensure => latest` is set.
+
+Default value: `'default'`
 
 ## Resource types
 
@@ -630,7 +657,7 @@ Default value: `present`
 The targets to install or remove.
 
 Each target must be a Hash with three entries:
-  * `ensure`: one of `present` and `absent`
+  * `ensure`: one of `present` or `absent`
   * `target`: the name of the target
   * `toolchain`: the name of the toolchain or `undef` to indicate the
     default toolchain
@@ -640,8 +667,9 @@ Each target must be a Hash with three entries:
 The toolchains to install, update, or remove.
 
 Each toolchain must be a Hash with two entries:
-  * `ensure`: one of `present`, `latest`, and `absent`
+  * `ensure`: one of `present`, `latest`, or `absent`
   * `toolchain`: the name of the toolchain
+  * `profile`: one of `minimal`, `default`, or `complete`
 
 #### Parameters
 
@@ -750,5 +778,15 @@ Alias of
 
 ```puppet
 Variant[Undef, String[1], Array[String[1]]]
+```
+
+### <a name="rustupprofile"></a>`Rustup::Profile`
+
+`default` is a keyword in Puppet, so it must always be wrapped in quotes.
+
+Alias of
+
+```puppet
+Enum[minimal, 'default', complete]
 ```
 

--- a/lib/puppet/provider/rustup_internal/default.rb
+++ b/lib/puppet/provider/rustup_internal/default.rb
@@ -35,6 +35,9 @@ Puppet::Type.type(:rustup_internal).provide(
 
   # Load toolchains from the system
   #
+  # Does not try to set the `profile`, since it’s meaningless after the initial
+  # installation of the toolchain.
+  #
   # Saves the toolchains to @toolchains_cache.
   def load_toolchains
     @toolchains_cache = toolchain_list.map do |full_name|
@@ -367,7 +370,7 @@ Puppet::Type.type(:rustup_internal).provide(
           toolchain_uninstall(info['toolchain'])
         end
       elsif found.nil? || info['ensure'] == 'latest'
-        toolchain_install(info['toolchain'])
+        toolchain_install(info['toolchain'], profile: info['profile'])
       end
     end
 
@@ -434,9 +437,9 @@ Puppet::Type.type(:rustup_internal).provide(
   end
 
   # Install or update a toolchain
-  def toolchain_install(toolchain)
+  def toolchain_install(toolchain, profile: 'default')
     rustup 'toolchain', 'install', '--no-self-update', '--force-non-host', \
-      toolchain
+      '--profile', profile, toolchain
   end
 
   # Uninstall a toolchain

--- a/manifests/global/toolchain.pp
+++ b/manifests/global/toolchain.pp
@@ -12,9 +12,16 @@
 #   * `absent` - uninstall toolchain.
 # @param toolchain
 #   The name of the toolchain to install, e.g. "stable".
+# @param profile
+#   Profile to use for installation. This determines which components will be
+#   installed initially.
+#
+#   Changing this for an existing installation will not have an effect even if
+#   it causes an update, i.e. when `ensure => latest` is set.
 define rustup::global::toolchain (
   Enum[present, latest, absent] $ensure    = present,
   String[1]                     $toolchain = $name,
+  Rustup::Profile               $profile   = 'default',
 ) {
   include rustup::global
 
@@ -22,5 +29,6 @@ define rustup::global::toolchain (
     ensure    => $ensure,
     rustup    => $rustup::global::user,
     toolchain => $toolchain,
+    profile   => $profile,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,7 @@ define rustup (
       {
         ensure    => present,
         toolchain => $toolchain,
+        profile   => 'default',
       }
     }
 

--- a/manifests/toolchain.pp
+++ b/manifests/toolchain.pp
@@ -18,15 +18,23 @@
 # @param toolchain
 #   The name of the toolchain to install, e.g. "stable". Automatically set if
 #   the `$name` of the resource follows the rules above.
+# @param profile
+#   Profile to use for installation. This determines which components will be
+#   installed initially.
+#
+#   Changing this for an existing installation will not have an effect even if
+#   it causes an update, i.e. when `ensure => latest` is set.
 define rustup::toolchain (
   Enum[present, latest, absent] $ensure    = present,
   String[1]                     $rustup    = $name.split(': ')[0],
   String[1]                     $toolchain = $name.split(': ')[1],
+  Rustup::Profile               $profile   = 'default',
 ) {
   Rustup_internal <| title == $rustup |> {
     toolchains +> [{
         ensure    => $ensure,
         toolchain => $toolchain,
+        profile   => $profile,
     }],
   }
 }

--- a/types/profile.pp
+++ b/types/profile.pp
@@ -1,0 +1,4 @@
+# @summary Profile for toolchain installation
+#
+# `default` is a keyword in Puppet, so it must always be wrapped in quotes.
+type Rustup::Profile = Enum[minimal, 'default', complete]


### PR DESCRIPTION
This allows the profile to be set when installing toolchains. It only has an effect during the initial install. All it does is decide which components are installed by default.