### PR TITLE
Add option to install pre-release toolchains

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -53,6 +53,7 @@ The following parameters are available in the `rustup::global` class:
 * [`manage_user`](#manage_user)
 * [`purge_toolchains`](#purge_toolchains)
 * [`purge_targets`](#purge_targets)
+* [`dist_server`](#dist_server)
 * [`home`](#home)
 * [`shell`](#shell)
 * [`env_scripts_append`](#env_scripts_append)
@@ -101,6 +102,15 @@ Data type: `Boolean`
 Whether or not to uninstall targets that aren’t managed by Puppet.
 
 Default value: ``false``
+
+##### <a name="dist_server"></a>`dist_server`
+
+Data type: `Optional[Stdlib::HTTPUrl]`
+
+Override `RUSTUP_DIST_SERVER`. Set to `'https://dev-static.rust-lang.org'`
+to install pre-release toolchains.
+
+Default value: ``undef``
 
 ##### <a name="home"></a>`home`
 
@@ -169,6 +179,7 @@ The following parameters are available in the `rustup` defined type:
 * [`purge_toolchains`](#purge_toolchains)
 * [`targets`](#targets)
 * [`purge_targets`](#purge_targets)
+* [`dist_server`](#dist_server)
 * [`home`](#home)
 * [`rustup_home`](#rustup_home)
 * [`cargo_home`](#cargo_home)
@@ -237,6 +248,15 @@ Data type: `Boolean`
 Whether or not to uninstall targets that aren’t managed by Puppet.
 
 Default value: ``false``
+
+##### <a name="dist_server"></a>`dist_server`
+
+Data type: `Optional[Stdlib::HTTPUrl]`
+
+Override `RUSTUP_DIST_SERVER`. Set to `'https://dev-static.rust-lang.org'`
+to install pre-release toolchains.
+
+Default value: ``undef``
 
 ##### <a name="home"></a>`home`
 
@@ -676,6 +696,7 @@ Each toolchain must be a Hash with two entries:
 The following parameters are available in the `rustup_internal` type.
 
 * [`cargo_home`](#cargo_home)
+* [`dist_server`](#dist_server)
 * [`home`](#home)
 * [`installer_source`](#installer_source)
 * [`modify_path`](#modify_path)
@@ -691,6 +712,11 @@ Where `cargo` installs executables (autorequired). Generally you shouldn’t
 change this.
 
 Default value: `"${home}/.cargo"`
+
+##### <a name="dist_server"></a>`dist_server`
+
+Override `RUSTUP_DIST_SERVER`. Set to `'https://dev-static.rust-lang.org'`
+to install pre-release toolchains.
 
 ##### <a name="home"></a>`home`
 

--- a/lib/puppet/provider/rustup_exec.rb
+++ b/lib/puppet/provider/rustup_exec.rb
@@ -111,7 +111,8 @@ class Puppet::Provider::RustupExec < Puppet::Provider
       'PATH' => path_env,
       'RUSTUP_HOME' => resource[:rustup_home],
       'CARGO_HOME' => resource[:cargo_home],
-    }
+      'RUSTUP_DIST_SERVER' => resource[:dist_server],
+    }.compact
 
     debug do
       stdin_message = stdin_file ? " and stdin_file #{stdin_file.inspect}" : ''

--- a/lib/puppet/type/rustup_internal.rb
+++ b/lib/puppet/type/rustup_internal.rb
@@ -168,6 +168,25 @@ Puppet::Type.newtype(:rustup_internal) do
     defaultto true
   end
 
+  newparam(:dist_server) do
+    desc <<~'END'
+      Override `RUSTUP_DIST_SERVER`. Set to `'https://dev-static.rust-lang.org'`
+      to install pre-release toolchains.
+    END
+
+    validate do |value|
+      # undef is okay, but it doesn’t seem to be passed to this function.
+      unless PuppetX::Rustup::Util.non_empty_string?(value) \
+          && URI.parse(value).absolute?
+        # The message is ignored and recreated in the rescue clause.
+        raise Puppet::Error
+      end
+    rescue
+      raise Puppet::Error, 'dist_server must be a valid URL, not %s.' \
+        % value.inspect
+    end
+  end
+
   newparam(:modify_path, boolean: true, parent: Puppet::Parameter::Boolean) do
     desc <<~'END'
       Whether or not to let `rustup` modify the user’s `PATH` in their shell

--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -16,6 +16,9 @@
 #   Whether or not to uninstall toolchains that aren’t managed by Puppet.
 # @param purge_targets
 #   Whether or not to uninstall targets that aren’t managed by Puppet.
+# @param dist_server
+#   Override `RUSTUP_DIST_SERVER`. Set to `'https://dev-static.rust-lang.org'`
+#   to install pre-release toolchains.
 # @param home
 #   Where to install rustup and the rust toolchains. Will contain rustup and
 #   cargo directories.
@@ -34,6 +37,7 @@ class rustup::global (
   Boolean                       $manage_user        = true,
   Boolean                       $purge_toolchains   = false,
   Boolean                       $purge_targets      = false,
+  Optional[Stdlib::HTTPUrl]     $dist_server        = undef,
   Stdlib::Absolutepath          $home               = '/opt/rust',
   Stdlib::Absolutepath          $shell              = '/bin/bash',
   Array[Stdlib::Absolutepath]   $env_scripts_append = ['/etc/bashrc'],
@@ -134,6 +138,7 @@ class rustup::global (
     user             => $user,
     purge_toolchains => $purge_toolchains,
     purge_targets    => $purge_targets,
+    dist_server      => $dist_server,
     home             => $home,
     rustup_home      => $rustup_home,
     cargo_home       => $cargo_home,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,9 @@
 #   You can use `'default'` to indicate the target for the current host.
 # @param purge_targets
 #   Whether or not to uninstall targets that aren’t managed by Puppet.
+# @param dist_server
+#   Override `RUSTUP_DIST_SERVER`. Set to `'https://dev-static.rust-lang.org'`
+#   to install pre-release toolchains.
 # @param home
 #   The user’s home directory. This defaults to `/home/$user` on Linux and
 #   `/Users/$user` on macOS.
@@ -47,6 +50,7 @@ define rustup (
   Boolean                       $purge_toolchains  = false,
   Array[String[1]]              $targets           = [],
   Boolean                       $purge_targets     = false,
+  Optional[Stdlib::HTTPUrl]     $dist_server       = undef,
   Stdlib::Absolutepath          $home              = rustup::home($user),
   Stdlib::Absolutepath          $rustup_home       = "${home}/.rustup",
   Stdlib::Absolutepath          $cargo_home        = "${home}/.cargo",
@@ -82,6 +86,7 @@ define rustup (
     purge_toolchains  => $purge_toolchains,
     targets           => $_targets,
     purge_targets     => $purge_targets,
+    dist_server       => $dist_server,
     home              => $home,
     rustup_home       => $rustup_home,
     cargo_home        => $cargo_home,

--- a/spec/unit/puppet/type/rustup_internal_spec.rb
+++ b/spec/unit/puppet/type/rustup_internal_spec.rb
@@ -59,28 +59,42 @@ RSpec.describe Puppet::Type.type(:rustup_internal) do
       .not_to be_nil
   end
 
-  it 'fails with a number installer_source' do
-    expect { described_class.new(title: 'user', installer_source: 3) }
-      .to raise_error(Puppet::Error, %r{Installer source must be a valid URL})
+  context 'dist_server' do
+    it 'fails with a number' do
+      expect { described_class.new(title: 'user', dist_server: 3) }
+        .to raise_error(Puppet::Error, %r{dist_server must be a valid URL})
+    end
+
+    it 'fails with a blank' do
+      expect { described_class.new(title: 'user', dist_server: '') }
+        .to raise_error(Puppet::Error, %r{dist_server must be a valid URL})
+    end
+
+    it 'fails with a non-URL' do
+      expect { described_class.new(title: 'user', dist_server: 's a as') }
+        .to raise_error(Puppet::Error, %r{dist_server must be a valid URL})
+    end
+
+    it 'works with a URL' do
+      expect(described_class.new(title: 'user', dist_server: 'http://test'))
+        .not_to be_nil
+    end
   end
 
-  it 'fails with a nil installer_source' do
-    expect { described_class.new(title: 'user', installer_source: nil) }
-      .to raise_error(Puppet::Error, %r{Got nil value for installer_source})
-  end
+  context 'installer_source' do
+    it 'fails with a blank' do
+      expect { described_class.new(title: 'user', installer_source: '') }
+        .to raise_error(Puppet::Error, %r{Installer source must be a valid URL})
+    end
 
-  it 'fails with a blank installer_source' do
-    expect { described_class.new(title: 'user', installer_source: '') }
-      .to raise_error(Puppet::Error, %r{Installer source must be a valid URL})
-  end
+    it 'fails with a non-URL' do
+      expect { described_class.new(title: 'user', installer_source: 's a as') }
+        .to raise_error(Puppet::Error, %r{Installer source must be a valid URL})
+    end
 
-  it 'fails with a non-URL installer_source' do
-    expect { described_class.new(title: 'user', installer_source: 's a as') }
-      .to raise_error(Puppet::Error, %r{Installer source must be a valid URL})
-  end
-
-  it 'works with a URL installer_source' do
-    expect(described_class.new(title: 'user', installer_source: 'http://localhost/foo'))
-      .not_to be_nil
+    it 'works with a URL' do
+      expect(described_class.new(title: 'user', installer_source: 'http://foo'))
+        .not_to be_nil
+    end
   end
 end


### PR DESCRIPTION
This adds a `dist_server` parameter that can be set to `'https://dev-static.rust-lang.org'` to install pre-release toolchains. This works by setting the `RUSTUP_DIST_SERVER` environment variable.