### PR TITLE
Option to make tracing rustup commands easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,23 @@ rustup::global::target { 'default nightly': }
 rustup::global::target { 'x86_64-unknown-linux-musl nightly': }
 ~~~
 
+### Debugging
+
+To see what the module is doing under the hood, you can set the `RUSTUP_TRACE`
+environment variable and run puppet with verbose mode:
+
+~~~
+$ RUSTUP_TRACE= puppet apply --verbose -e 'rustup { "daniel": }'
+Info: Loading facts
+Notice: Compiled catalog for marlow.local in environment production in 0.05 seconds
+Info: Using environment 'production'
+Info: Applying configuration version '1663673350'
+Info: rustup_internal: as daniel: /Users/daniel/.cargo/bin/rustup toolchain list
+Info: rustup_internal: as daniel: /Users/daniel/.cargo/bin/rustup target list --toolchain stable-x86_64-apple-darwin
+Info: rustup_internal: as daniel: /Users/daniel/.cargo/bin/rustup target list --toolchain nightly-x86_64-apple-darwin
+Notice: Applied catalog in 0.22 seconds
+~~~
+
 ## Limitations
 
   * This does not allow management of components.

--- a/lib/puppet/provider/rustup_exec.rb
+++ b/lib/puppet/provider/rustup_exec.rb
@@ -120,6 +120,10 @@ class Puppet::Provider::RustupExec < Puppet::Provider
       "environment #{environment.inspect}#{stdin_message}"
     end
 
+    if ENV['RUSTUP_TRACE']
+      info("as #{resource[:user]}: #{command.join(' ')}")
+    end
+
     # FIXME: timeout?
     Puppet::Util::Execution.execute(
       command,


### PR DESCRIPTION
This module now outputs the commands being executed (e.g.
`/home/user/.cargo/bin/rustup toolchain install stable`) at the info
logging level (enabled by `--verbose`) when the `RUSTUP_TRACE`
environment variable is set.

It makes it easier to see what’s going on under the hood without
enabling all debugging messages.
