### PR TITLE
Fix default values in REFERENCE.md

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -336,7 +336,7 @@ Data type: `String[1]`
 The user to run as. Automatically set if the `$name` of the resource follows
 the rules above.
 
-Default value: `(': ')[0]`
+Default value: `split($name, ': ')[0]`
 
 ##### <a name="command"></a>`command`
 
@@ -345,7 +345,7 @@ Data type: `String[1]`
 The command to run, e.g. 'rustup default stable'. Automatically set if the
 `$name` of the resource follows the rules above.
 
-Default value: `(': ')[1]`
+Default value: `split($name, ': ')[1]`
 
 ##### <a name="creates"></a>`creates`
 
@@ -464,7 +464,7 @@ Data type: `String[1]`
 The name of the target to install, e.g. "sparcv9-sun-solaris". Automatically
 set if the `$name` of the resource follows the rules above.
 
-Default value: `(' ')[0]`
+Default value: `split($name, ' ')[0]`
 
 ##### <a name="toolchain"></a>`toolchain`
 
@@ -474,7 +474,7 @@ The name of the toolchain in which to install the target, e.g. "stable".
 `undef` means the default toolchain. Automatically set if the `$name` of the
 resource follows the rules above.
 
-Default value: `(' ')[1]`
+Default value: `split($name, ' ')[1]`
 
 ### <a name="rustupglobaltoolchain"></a>`rustup::global::toolchain`
 
@@ -560,7 +560,7 @@ Data type: `String[1]`
 The name of the `rustup` installation (normally the username). Automatically
 set if the `$name` of the resource follows the rules above.
 
-Default value: `(': ')[0]`
+Default value: `split($name, ': ')[0]`
 
 ##### <a name="target"></a>`target`
 
@@ -569,7 +569,7 @@ Data type: `String[1]`
 The name of the target to install, e.g. "sparcv9-sun-solaris". Automatically
 set if the `$name` of the resource follows the rules above.
 
-Default value: `(' ')[0]`
+Default value: `split(split($name, ': ')[1], ' ')[0]`
 
 ##### <a name="toolchain"></a>`toolchain`
 
@@ -579,7 +579,7 @@ The name of the toolchain in which to install the target, e.g. "stable".
 `undef` means the default toolchain. Automatically set if the `$name` of the
 resource follows the rules above.
 
-Default value: `(' ')[1]`
+Default value: `split(split($name, ': ')[1], ' ')[1]`
 
 ### <a name="rustuptoolchain"></a>`rustup::toolchain`
 
@@ -617,7 +617,7 @@ Data type: `String[1]`
 The name of the `rustup` installation (normally the username). Automatically
 set if the `$name` of the resource follows the rules above.
 
-Default value: `(': ')[0]`
+Default value: `split($name, ': ')[0]`
 
 ##### <a name="toolchain"></a>`toolchain`
 
@@ -626,7 +626,7 @@ Data type: `String[1]`
 The name of the toolchain to install, e.g. "stable". Automatically set if
 the `$name` of the resource follows the rules above.
 
-Default value: `(': ')[1]`
+Default value: `split($name, ': ')[1]`
 
 ##### <a name="profile"></a>`profile`
 

--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -41,8 +41,8 @@
 #
 # [`exec`]: https://puppet.com/docs/puppet/latest/types/exec.html
 define rustup::exec (
-  String[1]                     $user        = $name.split(': ')[0],
-  String[1]                     $command     = $name.split(': ')[1],
+  String[1]                     $user        = split($name, ': ')[0],
+  String[1]                     $command     = split($name, ': ')[1],
   Optional[String[1]]           $creates     = undef,
   Array[String[1]]              $environment = [],
   Rustup::OptionalStringOrArray $onlyif      = undef,

--- a/manifests/global/target.pp
+++ b/manifests/global/target.pp
@@ -18,8 +18,8 @@
 #   resource follows the rules above.
 define rustup::global::target (
   Enum[present, absent] $ensure    = present,
-  String[1]             $target    = $name.split(' ')[0],
-  Optional[String[1]]   $toolchain = $name.split(' ')[1],
+  String[1]             $target    = split($name, ' ')[0],
+  Optional[String[1]]   $toolchain = split($name, ' ')[1],
 ) {
   include rustup::global
 

--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -26,9 +26,9 @@
 #   resource follows the rules above.
 define rustup::target (
   Enum[present, absent] $ensure    = present,
-  String[1]             $rustup    = $name.split(': ')[0],
-  String[1]             $target    = $name.split(': ')[1].split(' ')[0],
-  Optional[String[1]]   $toolchain = $name.split(': ')[1].split(' ')[1],
+  String[1]             $rustup    = split($name, ': ')[0],
+  String[1]             $target    = split(split($name, ': ')[1], ' ')[0],
+  Optional[String[1]]   $toolchain = split(split($name, ': ')[1], ' ')[1],
 ) {
   Rustup_internal <| title == $rustup |> {
     targets +> [{

--- a/manifests/toolchain.pp
+++ b/manifests/toolchain.pp
@@ -26,8 +26,8 @@
 #   it causes an update, i.e. when `ensure => latest` is set.
 define rustup::toolchain (
   Enum[present, latest, absent] $ensure    = present,
-  String[1]                     $rustup    = $name.split(': ')[0],
-  String[1]                     $toolchain = $name.split(': ')[1],
+  String[1]                     $rustup    = split($name, ': ')[0],
+  String[1]                     $toolchain = split($name, ': ')[1],
   Rustup::Profile               $profile   = 'default',
 ) {
   Rustup_internal <| title == $rustup |> {


### PR DESCRIPTION
There seems to be [a bug in puppet strings][] that prevents default values from being outputted correctly in REFERENCE.md. Values of the form `$var.func(...)` would output as `(...)`.

This switches over to the `func($var, ...)` form, though unfortunately I think it is less readable.

[a bug in puppet strings]: https://github.com/puppetlabs/puppet-strings/issues/240