### PR TITLE
Switch back to more readable default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
   example, it is now possible to install the `x86_64-pc-windows-gnu` toolchain
   on a Linux host without warnings. ([PR #9][])
 * Fixed default values and anchor links in [REFERENCE.md](REFERENCE.md).
-  ([PR #14][], [PR #15][])
+  ([PR #14][], [PR #15][], [PR #20][])
 
 [PR #9]: https://github.com/danielparks/puppet-rustup/pull/9
 [PR #10]: https://github.com/danielparks/puppet-rustup/pull/10
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 [PR #13]: https://github.com/danielparks/puppet-rustup/pull/13
 [PR #14]: https://github.com/danielparks/puppet-rustup/pull/14
 [PR #15]: https://github.com/danielparks/puppet-rustup/pull/15
+[PR #20]: https://github.com/danielparks/puppet-rustup/pull/20
 
 
 ## Release 0.1.0

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -340,7 +340,7 @@ Data type: `String[1]`
 The user to run as. Automatically set if the `$name` of the resource follows
 the rules above.
 
-Default value: `split($name, ': ')[0]`
+Default value: `$name.split(': ')[0]`
 
 ##### <a name="-rustup--exec--command"></a>`command`
 
@@ -349,7 +349,7 @@ Data type: `String[1]`
 The command to run, e.g. 'rustup default stable'. Automatically set if the
 `$name` of the resource follows the rules above.
 
-Default value: `split($name, ': ')[1]`
+Default value: `$name.split(': ')[1]`
 
 ##### <a name="-rustup--exec--creates"></a>`creates`
 
@@ -468,7 +468,7 @@ Data type: `String[1]`
 The name of the target to install, e.g. "sparcv9-sun-solaris". Automatically
 set if the `$name` of the resource follows the rules above.
 
-Default value: `split($name, ' ')[0]`
+Default value: `$name.split(' ')[0]`
 
 ##### <a name="-rustup--global--target--toolchain"></a>`toolchain`
 
@@ -478,7 +478,7 @@ The name of the toolchain in which to install the target, e.g. "stable".
 `undef` means the default toolchain. Automatically set if the `$name` of the
 resource follows the rules above.
 
-Default value: `split($name, ' ')[1]`
+Default value: `$name.split(' ')[1]`
 
 ### <a name="rustup--global--toolchain"></a>`rustup::global::toolchain`
 
@@ -564,7 +564,7 @@ Data type: `String[1]`
 The name of the `rustup` installation (normally the username). Automatically
 set if the `$name` of the resource follows the rules above.
 
-Default value: `split($name, ': ')[0]`
+Default value: `$name.split(': ')[0]`
 
 ##### <a name="-rustup--target--target"></a>`target`
 
@@ -573,7 +573,7 @@ Data type: `String[1]`
 The name of the target to install, e.g. "sparcv9-sun-solaris". Automatically
 set if the `$name` of the resource follows the rules above.
 
-Default value: `split(split($name, ': ')[1], ' ')[0]`
+Default value: `$name.split(': ')[1].split(' ')[0]`
 
 ##### <a name="-rustup--target--toolchain"></a>`toolchain`
 
@@ -583,7 +583,7 @@ The name of the toolchain in which to install the target, e.g. "stable".
 `undef` means the default toolchain. Automatically set if the `$name` of the
 resource follows the rules above.
 
-Default value: `split(split($name, ': ')[1], ' ')[1]`
+Default value: `$name.split(': ')[1].split(' ')[1]`
 
 ### <a name="rustup--toolchain"></a>`rustup::toolchain`
 
@@ -621,7 +621,7 @@ Data type: `String[1]`
 The name of the `rustup` installation (normally the username). Automatically
 set if the `$name` of the resource follows the rules above.
 
-Default value: `split($name, ': ')[0]`
+Default value: `$name.split(': ')[0]`
 
 ##### <a name="-rustup--toolchain--toolchain"></a>`toolchain`
 
@@ -630,7 +630,7 @@ Data type: `String[1]`
 The name of the toolchain to install, e.g. "stable". Automatically set if
 the `$name` of the resource follows the rules above.
 
-Default value: `split($name, ': ')[1]`
+Default value: `$name.split(': ')[1]`
 
 ##### <a name="-rustup--toolchain--profile"></a>`profile`
 

--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -41,8 +41,8 @@
 #
 # [`exec`]: https://puppet.com/docs/puppet/latest/types/exec.html
 define rustup::exec (
-  String[1]                     $user        = split($name, ': ')[0],
-  String[1]                     $command     = split($name, ': ')[1],
+  String[1]                     $user        = $name.split(': ')[0],
+  String[1]                     $command     = $name.split(': ')[1],
   Optional[String[1]]           $creates     = undef,
   Array[String[1]]              $environment = [],
   Rustup::OptionalStringOrArray $onlyif      = undef,

--- a/manifests/global/target.pp
+++ b/manifests/global/target.pp
@@ -18,8 +18,8 @@
 #   resource follows the rules above.
 define rustup::global::target (
   Enum[present, absent] $ensure    = present,
-  String[1]             $target    = split($name, ' ')[0],
-  Optional[String[1]]   $toolchain = split($name, ' ')[1],
+  String[1]             $target    = $name.split(' ')[0],
+  Optional[String[1]]   $toolchain = $name.split(' ')[1],
 ) {
   include rustup::global
 

--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -26,9 +26,9 @@
 #   resource follows the rules above.
 define rustup::target (
   Enum[present, absent] $ensure    = present,
-  String[1]             $rustup    = split($name, ': ')[0],
-  String[1]             $target    = split(split($name, ': ')[1], ' ')[0],
-  Optional[String[1]]   $toolchain = split(split($name, ': ')[1], ' ')[1],
+  String[1]             $rustup    = $name.split(': ')[0],
+  String[1]             $target    = $name.split(': ')[1].split(' ')[0],
+  Optional[String[1]]   $toolchain = $name.split(': ')[1].split(' ')[1],
 ) {
   Rustup_internal <| title == $rustup |> {
     targets +> [{

--- a/manifests/toolchain.pp
+++ b/manifests/toolchain.pp
@@ -26,8 +26,8 @@
 #   it causes an update, i.e. when `ensure => latest` is set.
 define rustup::toolchain (
   Enum[present, latest, absent] $ensure    = present,
-  String[1]                     $rustup    = split($name, ': ')[0],
-  String[1]                     $toolchain = split($name, ': ')[1],
+  String[1]                     $rustup    = $name.split(': ')[0],
+  String[1]                     $toolchain = $name.split(': ')[1],
   Rustup::Profile               $profile   = 'default',
 ) {
   Rustup_internal <| title == $rustup |> {


### PR DESCRIPTION
Due to a [bug in Puppet Strings][bug], the default values were being outputted in REFERENCE.md incorrectly. Commit
c3db65ba4ea820e53adf9334bdd4ee245a4b5e03 fixed the problem at the cost of making the default values harder to understand.

I have fixed the bug in Puppet Strings (though it hasn’t been merged and released), so this reverts the aforementioned commit and generates a fresh REFERENCE.md.

[bug]: https://github.com/puppetlabs/puppet-strings/issues/240