### PR TITLE
Miscellaneous PDK configuration updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+; EditorConfig is awesome: http://EditorConfig.org
+
+root = true
+
+; Ruby style as default
+; UTF-8 charset
+; Unix-style newlines with a newline ending every file
+; 2 space indent
+; Trim trailing whitespace
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+; Markdown
+; 4 space indent
+; Trailing whitespace is potentially meaningful, leave it
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false
+
+; Shell scripts & Python
+; 4 space indent
+[*.{sh,py}]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.pdkignore
+++ b/.pdkignore
@@ -47,3 +47,4 @@
 /.devcontainer/
 /test.sh
 /util.sh
+/fix-reference.rb

--- a/.sync.yml
+++ b/.sync.yml
@@ -6,10 +6,18 @@
 # See https://github.com/puppetlabs/pdk-templates/blob/main/config_defaults.yml
 # for the default values.
 ---
+common:
+  disable_legacy_facts: true
+
+# Files not to include in the release package
 .pdkignore:
   paths:
     - /test.sh
     - /util.sh
+    - /fix-reference.rb
+
+.editorconfig:
+  unmanaged: false
 
 # Delete CI configuration we don’t use
 appveyor.yml:
@@ -22,13 +30,10 @@ appveyor.yml:
 Gemfile:
   optional:
     ':development':
-      - gem: 'github_changelog_generator'
       - gem: 'puppet_litmus'
         git: 'https://github.com/puppetlabs/puppet_litmus'
         ref: 'main'
 
-spec/spec_helper.rb:
-  mock_with: ':rspec'
 .rubocop.yml:
   default_configs:
     Layout/LineLength:

--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,8 @@ group :development do
   gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "voxpupuli-puppet-lint-plugins", '>= 3.0',                 require: false
-  gem "github_changelog_generator",                              require: false
   gem "puppet_litmus",                                           require: false, git: 'https://github.com/puppetlabs/puppet_litmus', ref: 'main'
+  gem "puppet-lint-legacy_facts-check",                          require: false
 end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]


### PR DESCRIPTION
  * Add `.editorconfig` since it seems like a good idea. Not sure why it’s off by default.
  * Disable github_changelog_generator since we don’t use it.
  * Add lint check for legacy facts.
  * Don’t bundle fix-reference.rb into the module release.
  * Remove spec_helper cconfiguration that didn’t do anything.