### PR TITLE
Switch back to require_relative

### DIFF
--- a/lib/puppet/provider/rustup_internal/default.rb
+++ b/lib/puppet/provider/rustup_internal/default.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'puppet/provider/rustup_exec'
-require 'puppet_x/rustup/util'
+require_relative '../rustup_exec'
+require_relative '../../../puppet_x/rustup/util'
 
 Puppet::Type.type(:rustup_internal).provide(
   :default, parent: Puppet::Provider::RustupExec

--- a/lib/puppet/type/rustup_internal.rb
+++ b/lib/puppet/type/rustup_internal.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require 'puppet/parameter/boolean'
-require 'puppet_x/rustup/util'
-require 'puppet_x/rustup/property/subresources'
+require_relative '../../puppet_x/rustup/util'
+require_relative '../../puppet_x/rustup/property/subresources'
 
 Puppet::Type.newtype(:rustup_internal) do
   @doc = <<~'END'

--- a/lib/puppet_x/rustup/property/set.rb
+++ b/lib/puppet_x/rustup/property/set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'puppet_x/rustup'
+require_relative '../../rustup'
 
 # Property classes for rustup
 module PuppetX::Rustup::Property

--- a/lib/puppet_x/rustup/property/subresources.rb
+++ b/lib/puppet_x/rustup/property/subresources.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'puppet_x/rustup/property/set'
+require_relative 'set'
 
 # Property classes for rustup
 module PuppetX::Rustup::Property

--- a/lib/puppet_x/rustup/util.rb
+++ b/lib/puppet_x/rustup/util.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'puppet_x/rustup'
+require_relative '../rustup'
 
 # Utility functions for rustup
 module PuppetX::Rustup::Util


### PR DESCRIPTION
Apparently using `require` within a Puppet module can violate environment isolation, since the puppetserver might search in other environments (or possibly not search at all if it’s cached) for the relevant files.

This doesn’t change file in spec, since those aren’t used within the puppetserver process.

Fixes #35