### PR TITLE
Fix subresource sync issues

### DIFF
--- a/lib/puppet_x/rustup/property/set.rb
+++ b/lib/puppet_x/rustup/property/set.rb
@@ -90,6 +90,11 @@ module PuppetX::Rustup::Property
       hash
     end
 
+    # Check if entries with the same identity are different.
+    def entry_changed?(is_entry, should_entry)
+      is_entry != should_entry
+    end
+
     # Check if the values are in sync.
     #
     # You should not need to override this.
@@ -108,12 +113,16 @@ module PuppetX::Rustup::Property
 
       # Remove entries in clean_should from clean_is.
       clean_should.each do |identity, should_entry|
-        if clean_is.delete(identity).nil?
+        is_entry = clean_is.delete(identity)
+        if is_entry.nil?
           # Found an entry in `should`, but not in `is`. If the entry has the
           # equivalent of `ensure => absent`, then it doesn’t matter.
           unless should_entry_absent? should_entry
             return false
           end
+        elsif entry_changed?(is_entry, should_entry)
+          # Found entries with the same identity, but different details.
+          return false
         end
       end
 

--- a/lib/puppet_x/rustup/property/set.rb
+++ b/lib/puppet_x/rustup/property/set.rb
@@ -103,11 +103,12 @@ module PuppetX::Rustup::Property
 
       begin
         clean_is = clean_set(is) { |e| normalize_is_entry(e) }
-      rescue Puppet::Error
+      rescue Puppet::Error => error
         # `clean_is` represents what actually exists, so if there are duplicates
         # it should not fail (though it should be considered a bug). Since we
         # don’t allow `should` to contain duplicates, a duplicate in `is` will
         # always indicate a change.
+        warn "Error in existing #{name}: #{error}"
         return false
       end
 

--- a/lib/puppet_x/rustup/property/subresources.rb
+++ b/lib/puppet_x/rustup/property/subresources.rb
@@ -17,7 +17,7 @@ module PuppetX::Rustup::Property
     # entry within in the set. If two entries have the same identity, then it
     # is an error.
     def entry_identity(entry)
-      entry.reject { |k| k == 'absent' }.hash
+      entry.reject { |k| k == 'ensure' }.hash
     end
 
     # Does this entry in `should` have the equivalent of `ensure => absent`?

--- a/spec/unit/puppet_x/rustup/property/set_spec.rb
+++ b/spec/unit/puppet_x/rustup/property/set_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe PuppetX::Rustup::Property::Set do
 
       it 'considers duplicate old entries to be a change' do
         property.should = ['a', 'b']
+        expect(property).to receive(:warn)
+          .with('Error in existing : Duplicate entry in set: "b"')
         expect(property.insync?(['a', 'b', 'b'])).to eq false
       end
     end

--- a/spec/unit/puppet_x/rustup/property/subresources_spec.rb
+++ b/spec/unit/puppet_x/rustup/property/subresources_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe PuppetX::Rustup::Property::Subresources do
 
       it 'considers duplicate old entries to be a change' do
         property.should = [example('a')]
+        expect(property).to receive(:warn)
+          .with(%r{\AError in existing : Duplicate entry in set: })
         expect(property.insync?([example('a'), example('a')])).to eq false
       end
 

--- a/spec/unit/puppet_x/rustup/property/subresources_spec.rb
+++ b/spec/unit/puppet_x/rustup/property/subresources_spec.rb
@@ -35,12 +35,22 @@ RSpec.describe PuppetX::Rustup::Property::Subresources do
       end
 
       it 'considers changing ensure to latest a change' do
+        skip 'broken until next commit'
         property.should = [example('a', ensure_: 'latest')]
         expect(property.insync?([example('a', ensure_: 'present')])).to eq false
       end
 
       it 'fails on duplicate new hashes' do
         property.should = [example('a'), example('a')]
+        expect { property.insync?([example('a')]) }
+          .to raise_error(Puppet::Error, %r{\ADuplicate entry in set: })
+      end
+
+      it 'fails on duplicate new hashes with different ensures' do
+        property.should = [
+          example('a', ensure_: 'present'),
+          example('a', ensure_: 'latest'),
+        ]
         expect { property.insync?([example('a')]) }
           .to raise_error(Puppet::Error, %r{\ADuplicate entry in set: })
       end

--- a/spec/unit/puppet_x/rustup/property/subresources_spec.rb
+++ b/spec/unit/puppet_x/rustup/property/subresources_spec.rb
@@ -35,8 +35,12 @@ RSpec.describe PuppetX::Rustup::Property::Subresources do
       end
 
       it 'considers changing ensure to latest a change' do
-        skip 'broken until next commit'
         property.should = [example('a', ensure_: 'latest')]
+        expect(property.insync?([example('a', ensure_: 'present')])).to eq false
+      end
+
+      it 'considers changing ensure to absent a change' do
+        property.should = [example('a', ensure_: 'absent')]
         expect(property.insync?([example('a', ensure_: 'present')])).to eq false
       end
 


### PR DESCRIPTION
### Fix subresource identity function

The identity function is supposed to uniquely identify a subresource in a set for the purpose of detecting defaults. At its most basic, it’s supposed to just just remove the `ensure` attribute and compute the hash so you can’t have two otherwise identical subresources with different values for `ensure`.

Previously it stripped an attribute called `absent` rather than the `ensure` attribute.

### Fix set comparison

Previously, entries in sets were considered to be unchanged if their identities were the same. In particular, it ignored most changes to `ensure`. This adds code to make sure that entries with the same identity are actually unchanged.

This also adds a warning when there’s an error normalizing and deduplicating the `is` array.

### To do

* [x] Maybe remove warning? not really a bad thing I guess?
* [x] Add tests
