### PR TITLE
Enable Layout/MultilineMethodCallIndentation set to indented

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,9 @@ Style/GuardClause:
 Style/Next:
   Description: Using next instead of if often makes things harder to read.
   Enabled: false
+Layout/MultilineMethodCallIndentation:
+  Description: aligned is awkward and hard to read.
+  EnforcedStyle: indented
 RSpec/MessageSpies:
   EnforcedStyle: receive
 Style/Documentation:

--- a/metadata.json
+++ b/metadata.json
@@ -82,5 +82,5 @@
   ],
   "pdk-version": "2.5.0",
   "template-url": "https://github.com/danielparks/pdk-templates#main",
-  "template-ref": "heads/main-0-g0644767"
+  "template-ref": "heads/main-0-g9bea466"
 }


### PR DESCRIPTION
I disabled the rubocop in the template, then ran `pdk update`.