### PR TITLE
Move subresource management code into new classes

### DIFF
--- a/lib/puppet/type/rustup_internal.rb
+++ b/lib/puppet/type/rustup_internal.rb
@@ -60,7 +60,7 @@ Puppet::Type.newtype(:rustup_internal) do
     end
 
     def insync?(is)
-      is == provider.normalize_toolchain(should)
+      is == provider.toolchains.normalize(should)
     end
   end
 
@@ -93,7 +93,7 @@ Puppet::Type.newtype(:rustup_internal) do
 
     # Do any normalization required for an entry in `should`
     def normalize_should_entry!(entry)
-      entry['toolchain'] = provider.normalize_toolchain(entry['toolchain'])
+      entry['toolchain'] = provider.toolchains.normalize(entry['toolchain'])
       # `rustup` ignores the profile after the initial install. Thus, the
       # profile key is irrelevant for detecting a change.
       entry.delete('profile')
@@ -139,7 +139,7 @@ Puppet::Type.newtype(:rustup_internal) do
       entry['toolchain'] = provider.normalize_toolchain_or_default(
         entry['toolchain'],
       )
-      entry['target'] = provider.normalize_target(entry['target'])
+      entry['target'] = provider.targets.normalize(entry['target'])
     end
   end
 

--- a/lib/puppet_x/rustup/provider.rb
+++ b/lib/puppet_x/rustup/provider.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require_relative '../rustup'
+
+# Support module for rustup providers
+module PuppetX::Rustup::Provider; end

--- a/lib/puppet_x/rustup/provider/subresources.rb
+++ b/lib/puppet_x/rustup/provider/subresources.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require_relative '../provider'
+
+# A subresource collection
+class PuppetX::Rustup::Provider::Subresources
+  include Enumerable
+
+  attr_writer :values
+
+  # Get subresources installed on the system.
+  def load
+    raise 'Unimplemented.'
+  end
+
+  # Use this to set the plural name for the class
+  def self.plural_name(name = nil)
+    @plural_name ||= name
+  end
+
+  def initialize(provider)
+    @provider = provider
+    @system = :unset
+    @values = nil
+  end
+
+  # Get the plural_name from the class
+  def plural_name
+    self.class.plural_name
+  end
+
+  # Implement Enumerable
+  def each
+    if block_given?
+      values.each { |value| yield value }
+      self
+    else
+      enum_for(__callee__)
+    end
+  end
+
+  # Either the toolchains set, or the toolchains on the system
+  def values
+    @values || system
+  end
+
+  # Get subresources installed on the system (memoized).
+  #
+  # Just memoizes load.
+  def system
+    if @system == :unset
+      load
+    end
+    @system
+  end
+
+  # Split subresource up by toolchain for management
+  #
+  # This also verifies that none of the subresources were requested for
+  # toolchains with ensure => absent.
+  #
+  # @params [Hash] resources[:name]
+  # @params [block] a block that takes |toolchain, subresources|
+  def group_subresources_by_toolchain(requested)
+    by_toolchain = requested.group_by do |info|
+      @provider.normalize_toolchain_or_default(info['toolchain'])
+    end
+
+    @provider.toolchains.system.each do |info|
+      yield info['toolchain'], by_toolchain.delete(info['toolchain']) || []
+    end
+
+    # Find subresources that were requested for uninstalled toolchains.
+    missing_toolchains = []
+    by_toolchain.each do |toolchain, subresources|
+      if subresources.any? { |info| info['ensure'] != 'absent' }
+        missing_toolchains << toolchain
+      end
+    end
+
+    unless missing_toolchains.empty?
+      raise Puppet::Error, "#{plural_name} were requested for toolchains " \
+        "that are not installed: #{missing_toolchains.join(', ')}"
+    end
+  end
+end

--- a/lib/puppet_x/rustup/provider/targets.rb
+++ b/lib/puppet_x/rustup/provider/targets.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require_relative 'subresources'
+
+# A target subresource collection
+class PuppetX::Rustup::Provider::Targets <
+    PuppetX::Rustup::Provider::Subresources
+  plural_name 'Targets'
+
+  # Get toolchains installed on the system.
+  def load
+    @system = @provider.toolchains.system.reduce([]) do |combined, info|
+      toolchain = info['toolchain']
+      combined + list_installed(toolchain).map do |target|
+        {
+          'ensure' => 'present',
+          'target' => target,
+          'toolchain' => toolchain,
+        }
+      end
+    end
+  end
+
+  # Install and uninstall targets as appropriate
+  #
+  # Note that this does not update the internal state after changing the system.
+  # You must call targets.load after this function if you need the target state
+  # to be correct.
+  def manage(requested, purge)
+    group_subresources_by_toolchain(requested) do |toolchain, infos|
+      unmanaged = list_installed(toolchain)
+
+      infos.each do |info|
+        target = normalize(info['target'])
+
+        found = unmanaged.delete(target)
+        if info['ensure'] == 'absent'
+          if found
+            uninstall(target, toolchain: toolchain)
+          end
+        elsif found.nil?
+          # ensure == 'present' implied
+          install(target, toolchain: toolchain)
+        end
+      end
+
+      if purge
+        unmanaged.each do |target|
+          uninstall(target, toolchain: toolchain)
+        end
+      end
+    end
+  end
+
+  # Normalize target.
+  def normalize(target)
+    if target == 'default'
+      @provider.default_target
+    else
+      target
+    end
+  end
+
+  # Get list of installed targets for a toolchain
+  def list_installed(toolchain)
+    @provider
+      .rustup('target', 'list', '--installed', *toolchain_option(toolchain))
+      .lines(chomp: true)
+      .reject { |line| line.start_with? 'error: ' }
+  end
+
+  # Install a target
+  def install(target, toolchain: nil)
+    @provider.rustup 'target', 'install', *toolchain_option(toolchain), target
+  end
+
+  # Uninstall a target
+  def uninstall(target, toolchain: nil)
+    @provider.rustup 'target', 'uninstall', *toolchain_option(toolchain), target
+  end
+
+  # Generate --toolchain option to pass to rustup function
+  def toolchain_option(toolchain)
+    if toolchain.nil?
+      []
+    else
+      ['--toolchain', toolchain]
+    end
+  end
+end

--- a/lib/puppet_x/rustup/provider/toolchains.rb
+++ b/lib/puppet_x/rustup/provider/toolchains.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+require_relative 'subresources'
+
+# A toolchain subresource collection
+class PuppetX::Rustup::Provider::Toolchains <
+    PuppetX::Rustup::Provider::Subresources
+  plural_name 'Toolchains'
+
+  def initialize(provider)
+    super
+    @system_default = :unset
+  end
+
+  # Get the real default toolchain on the system
+  def system_default
+    if @system_default == :unset
+      load
+    end
+    @system_default
+  end
+
+  # Is the passed toolchain already installed?
+  #
+  # @param [String] normalized toolchain name
+  # @return [Boolean]
+  def installed?(toolchain)
+    system.any? { |info| info['toolchain'] == toolchain }
+  end
+
+  # Get toolchains installed on the system.
+  def load
+    @system = list_installed.map do |full_name|
+      {
+        'ensure' => 'present',
+        'toolchain' => full_name,
+      }
+    end
+  end
+
+  # Install and uninstall toolchains as appropriate
+  #
+  # Note that this does not update the internal state after changing the system.
+  # You must call toolchains.load after this function if you need the toolchain
+  # state to be correct.
+  def manage(requested, purge, requested_default)
+    if requested_default
+      requested_default = normalize(requested_default)
+      validate_default(requested_default, requested, purge)
+    end
+
+    unmanaged = system.map { |info| info['toolchain'] }
+
+    # Use `resource[:toolchains]` instead of the `toolchains` method because the
+    # result of the `toolchains` method can change if the resource requested
+    # the same toolchains as existed on the system, and then the toolchains on
+    # the system changed.
+    requested.each do |info|
+      full_name = normalize(info['toolchain'])
+
+      # Look for toolchain in list of installed, unmanaged toolchains. Note
+      # that this could be a problem if we specify a toolchain twice (e.g.
+      # "stable" and "stable-x86_64-apple-darwin").
+      found = unmanaged.delete(full_name)
+
+      if info['ensure'] == 'absent'
+        if found
+          uninstall(info['toolchain'])
+        end
+      elsif found.nil? || info['ensure'] == 'latest'
+        install(info['toolchain'], profile: info['profile'])
+      end
+    end
+
+    if requested_default
+      update_default(requested_default)
+    end
+
+    if purge
+      unmanaged.each do |name|
+        uninstall(name)
+      end
+    end
+  end
+
+  # Normalize a toolchain (not nil).
+  #
+  # There are some flaws in this.
+  #
+  #   * This is kludged together. I didn’t take the time to figure out all the
+  #     edge cases that rustup deals with.
+  #
+  #   * It will break as soon as rust adds a new triple to run toolchains on.
+  def normalize(input)
+    if input.nil?
+      raise ArgumentError, 'normalize expects a string, not nil'
+    end
+
+    parse_partial(input)
+      .map
+      .with_index { |part, i| part || @provider.default_toolchain_triple[i] }
+      .compact
+      .join('-')
+  end
+
+  # Parse a partial toolchain descriptor into its parts.
+  #
+  # FIXME: this will break as soon as Rust adds a new platform for the toolchain
+  # to run on.
+  def parse_partial(input)
+    # From https://github.com/rust-lang/rustup/blob/732feb8a733a6ad5c56cd9b637b501e8fa54491e/src/dist/triple.rs
+    # rubocop:disable Style/StringLiterals
+    archs = [
+      "i386",
+      "i586",
+      "i686",
+      "x86_64",
+      "arm",
+      "armv7",
+      "armv7s",
+      "aarch64",
+      "mips",
+      "mipsel",
+      "mips64",
+      "mips64el",
+      "powerpc",
+      "powerpc64",
+      "powerpc64le",
+      "riscv64gc",
+      "s390x",
+      "loongarch64",
+    ].join('|')
+    oses = [
+      "pc-windows",
+      "unknown-linux",
+      "apple-darwin",
+      "unknown-netbsd",
+      "apple-ios",
+      "linux",
+      "rumprun-netbsd",
+      "unknown-freebsd",
+      "unknown-illumos",
+    ].join('|')
+    envs = [
+      "gnu",
+      "gnux32",
+      "msvc",
+      "gnueabi",
+      "gnueabihf",
+      "gnuabi64",
+      "androideabi",
+      "android",
+      "musl",
+    ].join('|')
+    # rubocop:enable Style/StringLiterals
+    re = %r{\A(.*?)(?:-(#{archs}))?(?:-(#{oses}))?(?:-(#{envs}))?\Z}
+    match = re.match(input)
+    if match.nil?
+      [nil, nil, nil, nil]
+    else
+      match[1, 4]
+    end
+  end
+
+  # Validate that the default toolchain is or will be installed
+  def validate_default(normalized_default, requested_toolchains, purge)
+    found = requested_toolchains.find do |info|
+      normalize(info['toolchain']) == normalized_default
+    end
+
+    if found
+      if found['ensure'] == 'absent'
+        raise Puppet::Error, "Requested #{normalized_default.inspect} as " \
+          'default toolchain, but also set it to ensure => absent'
+      end
+    elsif !installed?(normalized_default)
+      raise Puppet::Error, "Requested #{normalized_default.inspect} as " \
+        'default toolchain, but it is not installed'
+    elsif purge
+      raise Puppet::Error, "Requested #{normalized_default.inspect} as " \
+        'default toolchain, but it is being purged'
+    end
+  end
+
+  # Save default toolchain to system
+  def update_default(toolchain)
+    if toolchain != @system_default
+      @provider.rustup 'default', toolchain
+      @system_default = toolchain
+    end
+  end
+
+  # Load installed toolchains from system as an array of strings
+  #
+  # This also sets @system_default.
+  def list_installed
+    @system_default = nil
+    unless @provider.exists? && @provider.user_exists?
+      # If rustup isn’t installed, then no toolchains can exist. If the user
+      # doesn’t exist then either this resource is ensure => absent and
+      # everything will be deleted, or an error will be raised when it tries to
+      # install rustup for a non-existent user.
+      return []
+    end
+
+    @provider.rustup('toolchain', 'list')
+      .lines(chomp: true)
+      .reject { |line| line == 'no installed toolchains' }
+      .each do |line|
+        # delete_suffix! returns nil if there was no suffix.
+        if line.delete_suffix!(' (default)')
+          @system_default = line
+        end
+      end
+  end
+
+  # Install or update a toolchain
+  def install(toolchain, profile: 'default')
+    @provider.rustup 'toolchain', 'install', '--no-self-update',
+      '--force-non-host', '--profile', profile, toolchain
+  end
+
+  # Uninstall a toolchain
+  def uninstall(toolchain)
+    @provider.rustup 'toolchain', 'uninstall', toolchain
+  end
+end

--- a/spec/unit/puppet/provider/rustup_internal/default_spec.rb
+++ b/spec/unit/puppet/provider/rustup_internal/default_spec.rb
@@ -42,22 +42,22 @@ RSpec.describe Puppet::Type.type(:rustup_internal).provider(:default) do
 
     context 'correctly normalizes toolchain' do
       it '"stable"' do
-        expect(provider.normalize_toolchain('stable'))
+        expect(provider.toolchains.normalize('stable'))
           .to eq('stable-x86_64-apple-darwin')
       end
 
       it '"custom-toolchain"' do
-        expect(provider.normalize_toolchain('custom-toolchain'))
+        expect(provider.toolchains.normalize('custom-toolchain'))
           .to eq('custom-toolchain-x86_64-apple-darwin')
       end
 
       it '"custom-toolchain-mscv"' do
-        expect(provider.normalize_toolchain('custom-toolchain-msvc'))
+        expect(provider.toolchains.normalize('custom-toolchain-msvc'))
           .to eq('custom-toolchain-x86_64-apple-darwin-msvc')
       end
 
       it '"custom-toolchain-pc-windows"' do
-        expect(provider.normalize_toolchain('custom-toolchain-pc-windows'))
+        expect(provider.toolchains.normalize('custom-toolchain-pc-windows'))
           .to eq('custom-toolchain-x86_64-pc-windows')
       end
     end


### PR DESCRIPTION
This helps separate code managing targets and toolchains out from the general provider.

Fixes #17 