### PR TITLE
Reduce calls to rustup when managing targets

### DIFF
--- a/lib/puppet_x/rustup/provider/targets.rb
+++ b/lib/puppet_x/rustup/provider/targets.rb
@@ -27,8 +27,11 @@ class PuppetX::Rustup::Provider::Targets <
   # You must call targets.load after this function if you need the target state
   # to be correct.
   def manage(requested, purge)
+    system_grouped = system.group_by { |info| info['toolchain'] }
     group_subresources_by_toolchain(requested) do |toolchain, infos|
-      unmanaged = list_installed(toolchain)
+      unmanaged = (system_grouped[toolchain] || []).map do |info|
+        info['target']
+      end
 
       infos.each do |info|
         target = normalize(info['target'])


### PR DESCRIPTION
Use `system` instead of potentially calling out to `list_installed` multiple times when managing targets.