### PR TITLE
Fix display of changes to subresources

### DIFF
--- a/lib/puppet_x/rustup/property/subresources.rb
+++ b/lib/puppet_x/rustup/property/subresources.rb
@@ -100,5 +100,21 @@ module PuppetX::Rustup::Property
           }
       end
     end
+
+    # Format given value for display.
+    #
+    # Often we use a subresource class to handle subresource collections in the
+    # provider, which interferes with the display of changed values.
+    #
+    # @param value [Object] the value to format as a string
+    # @return [String] a pretty printing string
+    # rubocop:disable Naming/PredicateName
+    def is_to_s(value)
+      if value.is_a? PuppetX::Rustup::Provider::Subresources
+        value = value.values
+      end
+      super(value)
+    end
+    # rubocop:enable Naming/PredicateName
   end
 end


### PR DESCRIPTION
When a parameter changes, Puppet displays a change message with the old and new values. Switching to the subresource collection classes on the provider broke this display — the old value was displayed as an opaque ruby object.

This restores the change display to show the interior attributes of all subresourcces.