### PR TITLE
Clarify name of collection classes for provider

### DIFF
--- a/lib/puppet/provider/rustup_internal/default.rb
+++ b/lib/puppet/provider/rustup_internal/default.rb
@@ -2,8 +2,8 @@
 
 require_relative '../rustup_exec'
 require_relative '../../../puppet_x/rustup/util'
-require_relative '../../../puppet_x/rustup/provider/targets'
-require_relative '../../../puppet_x/rustup/provider/toolchains'
+require_relative '../../../puppet_x/rustup/provider/collection/targets'
+require_relative '../../../puppet_x/rustup/provider/collection/toolchains'
 
 Puppet::Type.type(:rustup_internal).provide(
   :default, parent: Puppet::Provider::RustupExec
@@ -12,8 +12,10 @@ Puppet::Type.type(:rustup_internal).provide(
 
   mk_resource_methods
 
-  subresource_collection :toolchains, PuppetX::Rustup::Provider::Toolchains
-  subresource_collection :targets, PuppetX::Rustup::Provider::Targets
+  subresource_collection :toolchains,
+    PuppetX::Rustup::Provider::Collection::Toolchains
+  subresource_collection :targets,
+    PuppetX::Rustup::Provider::Collection::Targets
 
   # Get the default toolchain, possibly as requested by the resource.
   #

--- a/lib/puppet_x/rustup/property/subresources.rb
+++ b/lib/puppet_x/rustup/property/subresources.rb
@@ -110,7 +110,7 @@ module PuppetX::Rustup::Property
     # @return [String] a pretty printing string
     # rubocop:disable Naming/PredicateName
     def is_to_s(value)
-      if value.is_a? PuppetX::Rustup::Provider::Subresources
+      if value.is_a? PuppetX::Rustup::Provider::Collection
         value = value.values
       end
       super(value)

--- a/lib/puppet_x/rustup/provider/collection.rb
+++ b/lib/puppet_x/rustup/provider/collection.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative '../provider'
+
+# A collection value in a provider
+class PuppetX::Rustup::Provider::Collection
+  include Enumerable
+
+  attr_writer :values
+
+  # Use this to set the plural name for the class
+  def self.plural_name(plural_name = nil)
+    @plural_name ||= plural_name
+  end
+
+  def initialize(provider)
+    @provider = provider
+    @system = :unset
+    @values = nil
+  end
+
+  # Get values actaully present on the system.
+  def load
+    raise 'Unimplemented.'
+  end
+
+  # Get the plural_name from the class
+  def plural_name
+    self.class.plural_name
+  end
+
+  # Implement Enumerable
+  def each
+    if block_given?
+      values.each { |value| yield value }
+      self
+    else
+      enum_for(__callee__)
+    end
+  end
+
+  # Either the toolchains set, or the toolchains on the system
+  def values
+    @values || system
+  end
+
+  # Get subresources installed on the system (memoized).
+  #
+  # Just memoizes load.
+  def system
+    if @system == :unset
+      load
+    end
+    @system
+  end
+end

--- a/lib/puppet_x/rustup/provider/collection/subresources.rb
+++ b/lib/puppet_x/rustup/provider/collection/subresources.rb
@@ -1,59 +1,10 @@
 # frozen_string_literal: true
 
-require_relative '../provider'
+require_relative '../collection'
 
 # A subresource collection
-class PuppetX::Rustup::Provider::Subresources
-  include Enumerable
-
-  attr_writer :values
-
-  # Get subresources installed on the system.
-  def load
-    raise 'Unimplemented.'
-  end
-
-  # Use this to set the plural name for the class
-  def self.plural_name(name = nil)
-    @plural_name ||= name
-  end
-
-  def initialize(provider)
-    @provider = provider
-    @system = :unset
-    @values = nil
-  end
-
-  # Get the plural_name from the class
-  def plural_name
-    self.class.plural_name
-  end
-
-  # Implement Enumerable
-  def each
-    if block_given?
-      values.each { |value| yield value }
-      self
-    else
-      enum_for(__callee__)
-    end
-  end
-
-  # Either the toolchains set, or the toolchains on the system
-  def values
-    @values || system
-  end
-
-  # Get subresources installed on the system (memoized).
-  #
-  # Just memoizes load.
-  def system
-    if @system == :unset
-      load
-    end
-    @system
-  end
-
+class PuppetX::Rustup::Provider::Collection::Subresources <
+    PuppetX::Rustup::Provider::Collection
   # Split subresource up by toolchain for management
   #
   # This also verifies that none of the subresources were requested for

--- a/lib/puppet_x/rustup/provider/collection/targets.rb
+++ b/lib/puppet_x/rustup/provider/collection/targets.rb
@@ -3,8 +3,8 @@
 require_relative 'subresources'
 
 # A target subresource collection
-class PuppetX::Rustup::Provider::Targets <
-    PuppetX::Rustup::Provider::Subresources
+class PuppetX::Rustup::Provider::Collection::Targets <
+    PuppetX::Rustup::Provider::Collection::Subresources
   plural_name 'Targets'
 
   # Get targets installed on the system.

--- a/lib/puppet_x/rustup/provider/collection/toolchains.rb
+++ b/lib/puppet_x/rustup/provider/collection/toolchains.rb
@@ -3,8 +3,8 @@
 require_relative 'subresources'
 
 # A toolchain subresource collection
-class PuppetX::Rustup::Provider::Toolchains <
-    PuppetX::Rustup::Provider::Subresources
+class PuppetX::Rustup::Provider::Collection::Toolchains <
+    PuppetX::Rustup::Provider::Collection::Subresources
   plural_name 'Toolchains'
 
   def initialize(provider)


### PR DESCRIPTION
This moves the collection classes from `PuppetX::Rustup::Provider` to `PuppetX::Rustup::Provider::Collection` for clarity. This will be more important if we decide to create classes for subresource objects.