### PR TITLE
Use 'name' instead of 'toolchain' in toolchain hash

### DIFF
--- a/lib/puppet/type/rustup_internal.rb
+++ b/lib/puppet/type/rustup_internal.rb
@@ -70,7 +70,7 @@ Puppet::Type.newtype(:rustup_internal) do
 
       Each toolchain must be a Hash with two entries:
         * `ensure`: one of `present`, `latest`, or `absent`
-        * `toolchain`: the name of the toolchain
+        * `name`: the name of the toolchain
         * `profile`: one of `minimal`, `default`, or `complete`
     END
 
@@ -82,7 +82,7 @@ Puppet::Type.newtype(:rustup_internal) do
       end
 
       validate_in(entry, 'ensure', ['present', 'latest', 'absent'])
-      validate_non_empty_string(entry, 'toolchain')
+      validate_non_empty_string(entry, 'name')
       validate_in(entry, 'profile', ['minimal', 'default', 'complete'])
     end
 
@@ -93,7 +93,7 @@ Puppet::Type.newtype(:rustup_internal) do
 
     # Do any normalization required for an entry in `should`
     def normalize_should_entry!(entry)
-      entry['toolchain'] = provider.toolchains.normalize(entry['toolchain'])
+      entry['name'] = provider.toolchains.normalize(entry['name'])
       # `rustup` ignores the profile after the initial install. Thus, the
       # profile key is irrelevant for detecting a change.
       entry.delete('profile')

--- a/lib/puppet_x/rustup/provider/collection/subresources.rb
+++ b/lib/puppet_x/rustup/provider/collection/subresources.rb
@@ -5,6 +5,14 @@ require_relative '../collection'
 # A subresource collection
 class PuppetX::Rustup::Provider::Collection::Subresources <
     PuppetX::Rustup::Provider::Collection
+  # Is the passed subresource already installed?
+  #
+  # @param [String] normalized subresource name
+  # @return [Boolean]
+  def installed?(name)
+    system.any? { |info| info['name'] == name }
+  end
+
   # Split subresource up by toolchain for management
   #
   # This also verifies that none of the subresources were requested for
@@ -13,19 +21,19 @@ class PuppetX::Rustup::Provider::Collection::Subresources <
   # @params [Hash] resources[:name]
   # @params [block] a block that takes |toolchain, subresources|
   def group_subresources_by_toolchain(requested)
-    by_toolchain = requested.group_by do |info|
-      @provider.normalize_toolchain_or_default(info['toolchain'])
+    by_toolchain = requested.group_by do |subresource|
+      @provider.normalize_toolchain_or_default(subresource['toolchain'])
     end
 
-    @provider.toolchains.system.each do |info|
-      yield info['toolchain'], by_toolchain.delete(info['toolchain']) || []
+    @provider.toolchains.system.each do |toolchain|
+      yield toolchain['name'], by_toolchain.delete(toolchain['name']) || []
     end
 
     # Find subresources that were requested for uninstalled toolchains.
     missing_toolchains = []
-    by_toolchain.each do |toolchain, subresources|
-      if subresources.any? { |info| info['ensure'] != 'absent' }
-        missing_toolchains << toolchain
+    by_toolchain.each do |toolchain_name, subresources|
+      if subresources.any? { |subresource| subresource['ensure'] != 'absent' }
+        missing_toolchains << toolchain_name
       end
     end
 

--- a/lib/puppet_x/rustup/provider/collection/targets.rb
+++ b/lib/puppet_x/rustup/provider/collection/targets.rb
@@ -8,7 +8,7 @@ class PuppetX::Rustup::Provider::Collection::Targets <
   # Get targets installed on the system.
   def load
     @system = @provider.toolchains.system.reduce([]) do |combined, info|
-      toolchain = info['toolchain']
+      toolchain = info['name']
       combined + list_installed(toolchain).map do |target|
         {
           'ensure' => 'present',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,9 +63,9 @@ define rustup (
   } else {
     $_toolchains = $toolchains.map |$toolchain| {
       {
-        ensure    => present,
-        toolchain => $toolchain,
-        profile   => 'default',
+        ensure  => present,
+        name    => $toolchain,
+        profile => 'default',
       }
     }
 

--- a/manifests/toolchain.pp
+++ b/manifests/toolchain.pp
@@ -32,9 +32,9 @@ define rustup::toolchain (
 ) {
   Rustup_internal <| title == $rustup |> {
     toolchains +> [{
-        ensure    => $ensure,
-        toolchain => $toolchain,
-        profile   => $profile,
+        ensure  => $ensure,
+        name    => $toolchain,
+        profile => $profile,
     }],
   }
 }


### PR DESCRIPTION
I think it will be easier to share code if all subresources call the name key in their hashes 'name'. This takes the first step toward that by modifying the toolchain hash.

This also clarifies a few variable names.