### PR TITLE
Use 'name' instead of 'target' in target hash

### DIFF
--- a/lib/puppet/type/rustup_internal.rb
+++ b/lib/puppet/type/rustup_internal.rb
@@ -112,7 +112,7 @@ Puppet::Type.newtype(:rustup_internal) do
 
       Each target must be a Hash with three entries:
         * `ensure`: one of `present` or `absent`
-        * `target`: the name of the target
+        * `name`: the name of the target
         * `toolchain`: the name of the toolchain or `undef` to indicate the
           default toolchain
     END
@@ -125,7 +125,7 @@ Puppet::Type.newtype(:rustup_internal) do
       end
 
       validate_in(entry, 'ensure', ['present', 'absent'])
-      validate_non_empty_string(entry, 'target')
+      validate_non_empty_string(entry, 'name')
       validate_nil_or_non_empty_string(entry, 'toolchain')
     end
 
@@ -139,7 +139,7 @@ Puppet::Type.newtype(:rustup_internal) do
       entry['toolchain'] = provider.normalize_toolchain_or_default(
         entry['toolchain'],
       )
-      entry['target'] = provider.targets.normalize(entry['target'])
+      entry['name'] = provider.targets.normalize(entry['name'])
     end
   end
 

--- a/lib/puppet_x/rustup/provider/collection/targets.rb
+++ b/lib/puppet_x/rustup/provider/collection/targets.rb
@@ -8,12 +8,12 @@ class PuppetX::Rustup::Provider::Collection::Targets <
   # Get targets installed on the system.
   def load
     @system = @provider.toolchains.system.reduce([]) do |combined, info|
-      toolchain = info['name']
-      combined + list_installed(toolchain).map do |target|
+      toolchain_name = info['name']
+      combined + list_installed(toolchain_name).map do |target_name|
         {
           'ensure' => 'present',
-          'target' => target,
-          'toolchain' => toolchain,
+          'name' => target_name,
+          'toolchain' => toolchain_name,
         }
       end
     end
@@ -27,12 +27,10 @@ class PuppetX::Rustup::Provider::Collection::Targets <
   def manage(requested, purge)
     system_grouped = system.group_by { |info| info['toolchain'] }
     group_subresources_by_toolchain(requested) do |toolchain, infos|
-      unmanaged = (system_grouped[toolchain] || []).map do |info|
-        info['target']
-      end
+      unmanaged = (system_grouped[toolchain] || []).map { |info| info['name'] }
 
       infos.each do |info|
-        target = normalize(info['target'])
+        target = normalize(info['name'])
 
         found = unmanaged.delete(target)
         if info['ensure'] == 'absent'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,7 +72,7 @@ define rustup (
     $_targets = $targets.map |$target| {
       {
         ensure    => present,
-        target    => $target.split(' ')[0],
+        name      => $target.split(' ')[0],
         toolchain => $target.split(' ')[1],
       }
     }

--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -33,7 +33,7 @@ define rustup::target (
   Rustup_internal <| title == $rustup |> {
     targets +> [{
         ensure    => $ensure,
-        target    => $target,
+        name      => $target,
         toolchain => $toolchain,
     }],
   }


### PR DESCRIPTION
This finishes my switch to using a 'name' key in subresource hashes.