### PR TITLE
Fix old values for subresources in change display

### DIFF
--- a/lib/puppet_x/rustup/property/subresources.rb
+++ b/lib/puppet_x/rustup/property/subresources.rb
@@ -111,7 +111,7 @@ module PuppetX::Rustup::Property
     # rubocop:disable Naming/PredicateName
     def is_to_s(value)
       if value.is_a? PuppetX::Rustup::Provider::Collection
-        value = value.values
+        value = value.system
       end
       super(value)
     end


### PR DESCRIPTION
When a property changes on a resource, Puppet displays a change message with the old and new values. Previously, the value displayed as “old” was actually just the new values.

This fixes the problem.

It appears that Puppet may expect the collection object to be replaced rather than change.

Fixes #61 — Change messages for subresources don’t show old values