### PR TITLE
pdk update

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -10,15 +10,16 @@ on:
 jobs:
   validate:
     name: Validate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: "2.7"
-        bundler-cache: true
-    - run: gem install --no-document --minimal-deps pdk
+    - name: Install pdk
+      run: |
+        wget https://apt.puppet.com/puppet-tools-release-jammy.deb
+        sudo dpkg -i puppet-tools-release-jammy.deb
+        sudo apt-get update
+        sudo apt-get install -y pdk
     - run: pdk validate
 
     - run: pdk bundle exec puppet strings generate --format markdown

--- a/metadata.json
+++ b/metadata.json
@@ -82,5 +82,5 @@
   ],
   "pdk-version": "2.7.1",
   "template-url": "https://github.com/danielparks/pdk-templates#main",
-  "template-ref": "heads/main-0-g60fcead"
+  "template-ref": "heads/main-0-g936435d"
 }


### PR DESCRIPTION
Aside from Puppet-side changes, this fixes the PR Checks GitHub action so that it works with Puppet 8. Or something. I’m not really clear why it was failing, but this fixes it.