### PR TITLE
Force native architecture for rustup bootstrap on MacOS (fix lints)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+* Changed initial installation on macOS to always use the native architecture.
+  This avoids performance issues when Puppet is run in x86_64 emulation mode
+  (Rosetta) on ARM (e.g. when run from Bolt). Thanks to [Zac Bentley][@zbentley]
+  for [finding][#80] and [fixing][#81] the issue.
+
+[@zbentley]: https://github.com/zbentley
+[#80]: https://github.com/danielparks/puppet-rustup/issues/80
+[#81]: https://github.com/danielparks/puppet-rustup/pull/81
+
 ## Release 0.2.3
 
 * Synced with [PDK][].

--- a/lib/puppet/provider/rustup_internal/default.rb
+++ b/lib/puppet/provider/rustup_internal/default.rb
@@ -39,13 +39,13 @@ Puppet::Type.type(:rustup_internal).provide(
     # wish to run it as will have access, even with chmod.)
     PuppetX::Rustup::Util.download(url, ['puppet-rustup-init', '.sh']) do |sh|
       command = ['/bin/sh', '-s', '--', '-y', '--default-toolchain', 'none']
-      if Facter.value("os")["family"] == "darwin"
-        # On MacOS, ensure the rustup bootstrap is run as the native architecture.
-        # If this is not done, the architecture of the Ruby running this process
-        # may be used to compile the default Rust toolchain/cargo/etc, which can
-        # cause those tools to run under Rosetta, harming performance and causing
-        # issues:
-        command = ["/usr/bin/arch", "-64"] + command
+      if Facter.value('os')['family'] == 'darwin'
+        # On MacOS, ensure the rustup bootstrap is run as the native
+        # architecture. If this is not done, the architecture of the Ruby
+        # running this process may be used to compile the default Rust
+        # toolchain/cargo/etc, which can cause those tools to run under Rosetta,
+        # harming performance and causing issues:
+        command = ['/usr/bin/arch', '-64'] + command
       end
       unless resource[:modify_path]
         command << '--no-modify-path'

--- a/lib/puppet/provider/rustup_internal/default.rb
+++ b/lib/puppet/provider/rustup_internal/default.rb
@@ -39,6 +39,14 @@ Puppet::Type.type(:rustup_internal).provide(
     # wish to run it as will have access, even with chmod.)
     PuppetX::Rustup::Util.download(url, ['puppet-rustup-init', '.sh']) do |sh|
       command = ['/bin/sh', '-s', '--', '-y', '--default-toolchain', 'none']
+      if Facter.value("os")["family"] == "darwin"
+        # On MacOS, ensure the rustup bootstrap is run as the native architecture.
+        # If this is not done, the architecture of the Ruby running this process
+        # may be used to compile the default Rust toolchain/cargo/etc, which can
+        # cause those tools to run under Rosetta, harming performance and causing
+        # issues:
+        command = ["/usr/bin/arch", "-64"] + command
+      end
       unless resource[:modify_path]
         command << '--no-modify-path'
       end


### PR DESCRIPTION
This is the same as #81, just with commits to fix lints and add an entry in CHANGELOG.md.