### PR TITLE
Run acceptance tests directly on GitHub runners

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -8,23 +8,25 @@ on:
   pull_request:
 
 env:
-  validate_distro: jammy
+  # Enable rspec color output
+  SPEC_OPTS: --force-color
 
 jobs:
   validate:
     name: Validate
-    # This needs to match $env.validate_distro:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
-    - name: Install pdk
+    - name: Install PDK
       run: |
-        wget "https://apt.puppet.com/puppet-tools-release-${validate_distro}.deb"
-        sudo dpkg -i "puppet-tools-release-${validate_distro}.deb"
-        rm "puppet-tools-release-${validate_distro}.deb"
-        sudo apt-get update
-        sudo apt-get install -y pdk
+        set -ex
+        distro=$(lsb_release -cs)
+        curl -sSO  "https://apt.puppet.com/puppet-tools-release-${distro}.deb"
+        sudo dpkg -i "puppet-tools-release-${distro}.deb"
+        rm "puppet-tools-release-${distro}.deb"
+        sudo apt-get update -qq
+        sudo apt-get install -qy pdk
     - run: pdk validate
 
     - name: Confirm REFERENCE.md is up-to-date
@@ -53,19 +55,32 @@ jobs:
 
   test-acceptance:
     name: Acceptance tests
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['litmusimage/centos:7']
-        agent: ['puppet7', 'puppet8']
+        os:
+          - ubuntu-latest
+        agent:
+          - puppet7
+          - puppet8
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: "2.7"
-        bundler-cache: true
-    - run: bundle exec rake 'litmus:provision[docker, ${{ matrix.image }}]'
-    - run: bundle exec rake 'litmus:install_agent[${{ matrix.agent }}]'
-    - run: bundle exec rake 'litmus:install_module'
-    - run: bundle exec rake 'litmus:acceptance:parallel'
+    - name: Install Puppet
+      run: |
+        set -ex
+        distro=$(lsb_release -cs)
+        deb_name="${{ matrix.agent }}-release-${distro}.deb"
+        curl -sSO  "https://apt.puppet.com/${deb_name}"
+        sudo dpkg -i "$deb_name"
+        rm "$deb_name"
+        sudo apt-get update -qq
+        sudo apt-get install -qy puppet-agent pdk
+    - name: Build module
+      run: pdk build
+    - name: Install module
+      run: sudo -E /opt/puppetlabs/bin/puppet module install pkg/*.tar.gz
+    - name: Install PDK dependencies
+      run: sudo -E pdk bundle install
+    - name: Run acceptance tests
+      run: sudo -E pdk bundle exec rake litmus:acceptance:localhost

--- a/metadata.json
+++ b/metadata.json
@@ -82,5 +82,5 @@
   ],
   "pdk-version": "3.0.1",
   "template-url": "https://github.com/danielparks/pdk-templates#main",
-  "template-ref": "heads/main-0-g8a26e6f"
+  "template-ref": "heads/main-0-g516808d"
 }

--- a/provision.yaml
+++ b/provision.yaml
@@ -1,8 +1,12 @@
 ---
 vagrant:
   provisioner: vagrant
-  images: ['centos/7', 'ubuntu/trusty64']
+  images:
+    - centos/7
+    - ubuntu/trusty64
 docker:
   provisioner: docker
-  # Can’t get any of the recent Ubuntu or Debian images to work
-  images: ['litmusimage/centos:7']
+  images:
+    - litmusimage/centos:7
+    # On some projects (?) I get a read-only filesystem error on init:
+    # - litmusimage/ubuntu:22.04

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -367,9 +367,9 @@ describe 'Per-user rustup management' do
   end
 
   it 'can remove itself after the user was deleted' do
-    expect(user('rustup_test')).not_to exist
+    rm_user('rustup_test')
 
-    apply_manifest(<<~'END')
+    apply_manifest(<<~'END', catch_failures: true)
       user { 'rustup_test':
         ensure     => present,
         managehome => true,
@@ -394,7 +394,7 @@ describe 'Per-user rustup management' do
     expect(file('/home/rustup_test/.bashrc').content)
       .to eq %(# .bashrc\n. "$HOME/.cargo/env"\n)
 
-    apply_manifest(<<~'END')
+    apply_manifest(<<~'END', catch_failures: true)
       user { 'rustup_test':
         ensure => absent,
       }
@@ -419,24 +419,12 @@ describe 'Per-user rustup management' do
     expect(file('/home/rustup_test')).to exist
     expect(file('/home/rustup_test/.cargo')).not_to exist
     expect(file('/home/rustup_test/.bashrc').content).to eq %(# .bashrc\n)
-
-    # Clean up
-    apply_manifest(<<~'END')
-      user { 'rustup_test':
-        ensure => absent,
-      }
-
-      file { '/home/rustup_test':
-        ensure => absent,
-        force  => true,
-      }
-    END
   end
 
   it 'can remove itself after the user was deleted (with custom cargo_home)' do
-    expect(user('rustup_test')).not_to exist
+    rm_user('rustup_test')
 
-    apply_manifest(<<~'END')
+    apply_manifest(<<~'END', catch_failures: true)
       user { 'rustup_test':
         ensure     => present,
         managehome => true,
@@ -471,7 +459,7 @@ describe 'Per-user rustup management' do
     expect(file('/home/rustup_test/.bashrc').content)
       .to eq %(# .bashrc\n. "/home/rustup_test/a/b/.cargo/env"\n)
 
-    apply_manifest(<<~'END')
+    apply_manifest(<<~'END', catch_failures: true)
       user { 'rustup_test':
         ensure => absent,
       }
@@ -497,17 +485,5 @@ describe 'Per-user rustup management' do
     expect(file('/home/rustup_test')).to exist
     expect(file('/home/rustup_test/a/b/.cargo')).not_to exist
     expect(file('/home/rustup_test/.bashrc').content).to eq %(# .bashrc\n)
-
-    # Clean up
-    apply_manifest(<<~'END')
-      user { 'rustup_test':
-        ensure => absent,
-      }
-
-      file { '/home/rustup_test':
-        ensure => absent,
-        force  => true,
-      }
-    END
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
 # Created to use litmus per:
-# https://puppetlabs.github.io/litmus/Converting-modules-to-use-Litmus.html
+# https://puppetlabs.github.io/content-and-tooling-team/docs/litmus/usage/converting-modules-to-use-litmus/
 
 require 'puppet_litmus'
 PuppetLitmus.configure!
+
+# For some reason litmusimage/ubuntu:22.04 doesn’t come with sudo.
+RSpec.configure do |config|
+  config.before(:suite) do
+    litmus = Class.new.extend(PuppetLitmus)
+    litmus.apply_manifest("package { 'sudo': }", catch_failures: true)
+  end
+end
 
 require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -9,3 +9,16 @@ end
 def command_as_user(cmd)
   command("sudo -iu user #{cmd}")
 end
+
+def rm_user(name)
+  apply_manifest(<<~"END", catch_failures: true)
+    user { #{name}:
+      ensure => absent,
+    }
+
+    file { '/home/#{name}':
+      ensure => absent,
+      force  => true,
+    }
+  END
+end


### PR DESCRIPTION
This makes a bunch of updates, some of which actually come from my [PDK template](https://github.com/danielparks/pdk-templates/).

The big one is that it now runs acceptance tests in CI on the GitHub runners directly, rather than trying to spin up containers under Puppet Litmus.

Fixes #83 — Acceptance tests broken.