### PR TITLE
Compare to appropriate OS string

### DIFF
--- a/lib/puppet/provider/rustup_internal/default.rb
+++ b/lib/puppet/provider/rustup_internal/default.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:rustup_internal).provide(
     # wish to run it as will have access, even with chmod.)
     PuppetX::Rustup::Util.download(url, ['puppet-rustup-init', '.sh']) do |sh|
       command = ['/bin/sh', '-s', '--', '-y', '--default-toolchain', 'none']
-      if Facter.value('os')['family'] == 'darwin'
+      if Facter.value('os')['family'] == 'Darwin'
         # On MacOS, ensure the rustup bootstrap is run as the native
         # architecture. If this is not done, the architecture of the Ruby
         # running this process may be used to compile the default Rust


### PR DESCRIPTION
I made [a mistake](https://github.com/danielparks/puppet-rustup/issues/80#issuecomment-1948816447) in my [initial draft](https://github.com/danielparks/puppet-rustup/pull/81) of this PR and only tested on a customized `facter` environment that downcased `Darwin` (the standard Puppet OS-family fact value for MacOS) to `darwin` on my environment.

This PR rectifies that issue.

Sorry for the mistake!