### PR TITLE
Simplify acceptance tests in CI

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,11 +1,8 @@
 name: PR checks
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - $default-branch
   pull_request:
+  workflow_dispatch:
 
 env:
   # Enable rspec color output
@@ -17,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install PDK
       run: |
         set -ex
@@ -46,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: "2.7"
@@ -57,30 +54,40 @@ jobs:
     name: Acceptance tests
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-        agent:
-          - puppet7
-          - puppet8
+        include:
+          - os: ubuntu-latest
+            puppet: 6
+          - os: ubuntu-latest
+            puppet: 7
+          - os: ubuntu-latest
+            puppet: 8
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Puppet
       run: |
         set -ex
-        distro=$(lsb_release -cs)
-        deb_name="${{ matrix.agent }}-release-${distro}.deb"
-        curl -sSO  "https://apt.puppet.com/${deb_name}"
-        sudo dpkg -i "$deb_name"
-        rm "$deb_name"
-        sudo apt-get update -qq
-        sudo apt-get install -qy puppet-agent pdk
-    - name: Build module
-      run: pdk build
-    - name: Install module
-      run: sudo -E /opt/puppetlabs/bin/puppet module install pkg/*.tar.gz
+        case ${{ matrix.os }} in
+          macos*)
+            brew install --cask puppetlabs/puppet/puppet-agent-${{ matrix.puppet }}
+            brew install --cask puppetlabs/puppet/pdk
+          ;;
+          ubuntu*)
+            distro=$(lsb_release -cs)
+            deb_name="puppet${{ matrix.puppet }}-release-${distro}.deb"
+            curl -sSO  "https://apt.puppet.com/${deb_name}"
+            sudo dpkg -i "$deb_name"
+            rm "$deb_name"
+            sudo apt-get update -qq
+            sudo apt-get install -qy puppet-agent pdk
+          ;;
+          *)
+            echo ::error::Unsupported platform
+            exit 1
+          ;;
+        esac
     - name: Install PDK dependencies
-      run: sudo -E pdk bundle install
+      run: sudo -E /opt/puppetlabs/pdk/bin/pdk bundle install
     - name: Run acceptance tests
-      run: sudo -E pdk bundle exec rake litmus:acceptance:localhost
+      run: sudo -E /opt/puppetlabs/pdk/bin/pdk bundle exec rake litmus:acceptance:localhost

--- a/metadata.json
+++ b/metadata.json
@@ -82,5 +82,5 @@
   ],
   "pdk-version": "3.0.1",
   "template-url": "https://github.com/danielparks/pdk-templates#main",
-  "template-ref": "heads/main-0-g516808d"
+  "template-ref": "heads/main-0-gde8efe4"
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -8,9 +8,19 @@ PuppetLitmus.configure!
 
 # For some reason litmusimage/ubuntu:22.04 doesn’t come with sudo.
 RSpec.configure do |config|
-  config.before(:suite) do
-    litmus = Class.new.extend(PuppetLitmus)
-    litmus.apply_manifest("package { 'sudo': }", catch_failures: true)
+  if RUBY_PLATFORM.include?('linux')
+    config.before(:suite) do
+      litmus = Class.new.extend(PuppetLitmus)
+      litmus.apply_manifest("package { 'sudo': }", catch_failures: true)
+    end
+  end
+end
+
+def home
+  if RUBY_PLATFORM.include?('darwin')
+    '/Users'
+  else
+    '/home'
   end
 end
 


### PR DESCRIPTION
# Update template: PR checks improvements

  * Don’t use a full matrix in acceptance tests. This will allow us to only test the latest Puppet version on other platforms to save time and energy.
  * There’s no need to build the module or install it in acceptance tests; Puppet Litmus takes care of all of that.
  * Run accceptance tests on Puppet 6.
  * Support (but do not enable) macOS in acceptance tests.
  * Update actions/checkout to v4.
  * Disable PR checks on push because we don’t use caching, so PR cache isolation is not an issue for us.
  * Make platforms configurable.
  * Add basic macOS support (not enabled by default).