### PR TITLE
Acceptance tests: enable macOS 12

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -61,6 +61,8 @@ jobs:
             puppet: 7
           - os: ubuntu-latest
             puppet: 8
+          - os: macos-latest
+            puppet: 8
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.sync.yml
+++ b/.sync.yml
@@ -6,3 +6,6 @@
 # See https://github.com/danielparks/pdk-templates/blob/main/config_defaults.yml
 # for the default values.
 ---
+.github/workflows/pr-checks.yaml:
+  additional-platforms:
+    - macos-latest

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -147,7 +147,13 @@ Data type: `Array[Stdlib::Absolutepath]`
 
 Paths that will get links to the cargo environment script.
 
-Default value: `['/etc/profile.d/99-cargo.sh']`
+Default value:
+
+```puppet
+$facts['os']['family'] ? {
+    'Darwin' => [],
+    default  => ['/etc/profile.d/99-cargo.sh']
+```
 
 ##### <a name="-rustup--global--installer_source"></a>`installer_source`
 

--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -41,7 +41,10 @@ class rustup::global (
   Stdlib::Absolutepath          $home               = '/opt/rust',
   Stdlib::Absolutepath          $shell              = '/bin/bash',
   Array[Stdlib::Absolutepath]   $env_scripts_append = ['/etc/bashrc'],
-  Array[Stdlib::Absolutepath]   $env_scripts_create = ['/etc/profile.d/99-cargo.sh'],
+  Array[Stdlib::Absolutepath]   $env_scripts_create = $facts['os']['family'] ? {
+    'Darwin' => [],
+    default  => ['/etc/profile.d/99-cargo.sh'],
+  },
   Stdlib::HTTPUrl               $installer_source   = 'https://sh.rustup.rs',
 ) {
   $rustup_home = "${home}/rustup"

--- a/spec/acceptance/global_spec.rb
+++ b/spec/acceptance/global_spec.rb
@@ -3,11 +3,11 @@
 require 'spec_helper_acceptance'
 
 describe 'Global rustup management' do
-  context 'supports out-of-order targets and toolchains with a nologin shell' do
+  context 'supports out-of-order targets and toolchains with a false shell' do
     it do
       idempotent_apply(<<~'END')
         class { 'rustup::global':
-          shell            => '/usr/sbin/nologin',
+          shell            => '/bin/false',
           purge_toolchains => true,
           purge_targets    => true,
         }
@@ -19,7 +19,7 @@ describe 'Global rustup management' do
       END
 
       expect(user('rustup')).to belong_to_group 'rustup'
-      expect(user('rustup')).to have_login_shell '/usr/sbin/nologin'
+      expect(user('rustup')).to have_login_shell '/bin/false'
     end
 
     describe file('/opt/rust') do
@@ -52,11 +52,11 @@ describe 'Global rustup management' do
     end
   end
 
-  context 'supports uninstalling a target with a nologin shell' do
+  context 'supports uninstalling a target with a false shell' do
     it do
       idempotent_apply(<<~'END')
         class { 'rustup::global':
-          shell            => '/usr/sbin/nologin',
+          shell            => '/bin/false',
           purge_toolchains => true,
           purge_targets    => true,
         }
@@ -89,11 +89,11 @@ describe 'Global rustup management' do
     end
   end
 
-  context 'supports uninstalling a toolchain with a nologin shell' do
+  context 'supports uninstalling a toolchain with a false shell' do
     it do
       idempotent_apply(<<~'END')
         class { 'rustup::global':
-          shell            => '/usr/sbin/nologin',
+          shell            => '/bin/false',
           purge_toolchains => true,
           purge_targets    => true,
         }

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -198,7 +198,7 @@ describe 'Per-user rustup management' do
 
     describe command_as_user('rustup +stable target list') do
       its(:stdout) do
-        is_expected.to match(%r{-unknown-linux-.* \(installed\)$})
+        is_expected.to match(%r{^#{host_target} \(installed\)$})
       end
       its(:stderr) { is_expected.to eq '' }
       its(:exit_status) { is_expected.to eq 0 }
@@ -217,7 +217,7 @@ describe 'Per-user rustup management' do
       PUPPET
     end
 
-    toolchain_name = "beta-#{os[:arch]}-unknown-linux-gnu"
+    toolchain_name = "beta-#{host_target}"
     toolchain_path = "#{home}/user/.rustup/toolchains/#{toolchain_name}"
 
     describe file("#{toolchain_path}/bin/rustc") do
@@ -232,7 +232,7 @@ describe 'Per-user rustup management' do
 
     describe command_as_user('rustup +beta target list') do
       its(:stdout) do
-        is_expected.to match(%r{-unknown-linux-.* \(installed\)$})
+        is_expected.to match(%r{^#{host_target} \(installed\)$})
       end
       its(:stderr) { is_expected.to eq '' }
       its(:exit_status) { is_expected.to eq 0 }
@@ -250,7 +250,7 @@ describe 'Per-user rustup management' do
       PUPPET
     end
 
-    toolchain_name = "stable-#{os[:arch]}-unknown-linux-gnu"
+    toolchain_name = "stable-#{host_target}"
     toolchain_path = "#{home}/user/.rustup/toolchains/#{toolchain_name}"
 
     describe file("#{toolchain_path}/bin/rustc") do
@@ -261,7 +261,7 @@ describe 'Per-user rustup management' do
 
     describe command_as_user('rustup +stable target list') do
       its(:stdout) do
-        is_expected.to match(%r{-unknown-linux-.* \(installed\)$})
+        is_expected.to match(%r{^#{host_target} \(installed\)$})
       end
       its(:stderr) { is_expected.to eq '' }
       its(:exit_status) { is_expected.to eq 0 }
@@ -279,7 +279,7 @@ describe 'Per-user rustup management' do
       PUPPET
     end
 
-    toolchain_name = "stable-#{os[:arch]}-unknown-linux-gnu"
+    toolchain_name = "stable-#{host_target}"
     toolchain_path = "#{home}/user/.rustup/toolchains/#{toolchain_name}"
     describe file("#{toolchain_path}/bin/rustc") do
       it { is_expected.to be_file }
@@ -287,7 +287,7 @@ describe 'Per-user rustup management' do
       it { is_expected.to be_owned_by 'user' }
     end
 
-    toolchain_name = "nightly-#{os[:arch]}-unknown-linux-gnu"
+    toolchain_name = "nightly-#{host_target}"
     toolchain_path = "#{home}/user/.rustup/toolchains/#{toolchain_name}"
     describe file("#{toolchain_path}/bin/rustc") do
       it { is_expected.to be_file }
@@ -297,7 +297,7 @@ describe 'Per-user rustup management' do
 
     describe command_as_user('rustup toolchain list') do
       its(:stdout) do
-        is_expected.to match(%r{^nightly.*-unknown-linux-gnu \(default\)$})
+        is_expected.to match(%r{^#{toolchain_name} \(default\)$})
       end
       its(:stderr) { is_expected.to eq '' }
       its(:exit_status) { is_expected.to eq 0 }

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -139,7 +139,9 @@ describe 'Per-user rustup management' do
     # Also tests that dist_server works with an explicit undef.
     it do
       idempotent_apply(<<~'PUPPET')
-        package { 'gcc': } # Needed for cargo install
+        if $facts['os']['family'] != 'Darwin' {
+          package { 'gcc': } # Needed for cargo install
+        }
         rustup { 'user':
           dist_server => undef,
         }

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -5,12 +5,18 @@ require 'spec_helper_acceptance'
 describe 'Per-user rustup management' do
   it 'creates test user' do
     apply_manifest(<<~"PUPPET", catch_failures: true)
+      group { 'user':
+        ensure => present,
+      }
+
       # Don’t use managehome in case /etc/skel has rustup installed, as is the
       # case on GitHub CI runners.
       user { 'user':
         ensure     => present,
+        gid        => 'user',
         managehome => false,
         shell      => '/bin/bash',
+        require    => Group['user'],
       }
 
       file {
@@ -395,11 +401,17 @@ describe 'Per-user rustup management' do
     rm_user('rustup_test')
 
     apply_manifest(<<~"PUPPET", catch_failures: true)
+      group { 'rustup_test':
+        ensure => present,
+      }
+
       # Don’t use managehome in case /etc/skel has rustup installed, as is the
       # case on GitHub CI runners.
       user { 'rustup_test':
         ensure     => present,
+        gid        => 'rustup_test',
         managehome => false,
+        require    => Group['rustup_test'],
       }
 
       file {
@@ -458,11 +470,17 @@ describe 'Per-user rustup management' do
     rm_user('rustup_test')
 
     apply_manifest(<<~"PUPPET", catch_failures: true)
+      group { 'rustup_test':
+        ensure => present,
+      }
+
       # Don’t use managehome in case /etc/skel has rustup installed, as is the
       # case on GitHub CI runners.
       user { 'rustup_test':
         ensure     => present,
+        gid        => 'rustup_test',
         managehome => false,
+        require    => Group['rustup_test'],
       }
 
       file {

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -10,6 +10,16 @@ def command_as_user(cmd)
   command("sudo -iu user #{cmd}")
 end
 
+def host_target
+  if RUBY_PLATFORM.include?('linux')
+    "#{os[:arch]}-unknown-linux-gnu"
+  elsif RUBY_PLATFORM.include?('darwin')
+    "#{os[:arch]}-apple-darwin"
+  else
+    raise "Unsupported RUBY_PLATFORM: #{RUBY_PLATFORM.inspect}"
+  end
+end
+
 def rm_user(name)
   apply_manifest(<<~"END", catch_failures: true)
     user { #{name}:


### PR DESCRIPTION
- **Acceptance tests: macOS has no /etc/profile.d.**
- **Acceptance tests: macOS has no /usr/sbin/nologin.**
- **Acceptance tests: create groups before users (for macOS).**
- **Acceptance tests: macOS should already have gcc installed.**
- **Acceptance tests: support macOS Rust toolchains and targets.**
- **Acceptance tests: enable macOS 12.**
